### PR TITLE
Use memberIds field for workspace queries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -339,7 +339,7 @@ export default function App() {
 		}
 		const q = query(
 		collection(db, "workspaces"),
-		where("ownerId", "==", user.uid),
+		where("memberIds", "array-contains", user.uid),
 		orderBy("createdAt", "asc")
 		);
 		const unsub = onSnapshot(q, (snap) => {
@@ -442,6 +442,17 @@ export default function App() {
 		}
 	}
 
+
+	async function updateWorkspaceMembers(id, members) {
+		try {
+			await updateDoc(doc(db, "workspaces", id), {
+				members,
+				memberIds: Object.keys(members),
+			});
+		} catch (err) {
+			setBanner(`Update members failed: ${err.message}`);
+		}
+	}
 
 	function resetLocal() {
 		setBanner("Local cache cleared.");


### PR DESCRIPTION
## Summary
- query workspaces by `memberIds` array for current user
- add helper to keep `memberIds` synced with `members`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4d40d07348326a1b79f0b6a9213bc