### PR TITLE
Switch progress tracking to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Progress Tracker
+# Project Tracker
 
-This project is a Vite-powered React app backed by Firebase. It tracks progress in multiple workspaces and supports Google authentication.
+This project is a Vite-powered React app backed by Firebase. It tracks projects in multiple workspaces and supports Google authentication.
 
 ## Firebase configuration
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#1B1B2F" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <title>Progress Tracker</title>
+    <title>Project Tracker</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,11 +1,11 @@
 {
   "short_name": "Tracker",
-  "name": "Progress Tracker",
+  "name": "Project Tracker",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#1B1B2F",
   "theme_color": "#9D4EDD",
-  "description": "Track progress, goals, and projects across devices.",
+  "description": "Track projects, goals, and people across devices.",
   "icons": [
     {
       "src": "/icons/icon-192.png",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import {
 } from "firebase/firestore";
 import { firebaseConfig } from "./firebase-config";
 import Header from "./components/header/header";
-import ProgressOverview from "./components/progress-overview/progress-overview";
+import ProjectsOverview from "./components/projects-overview/projects-overview";
 import GoalsOverview from "./components/goals-overview/goals-overview";
 import PeopleOverview from "./components/people-overview/people-overview";
 import { PALETTES, Card, Button } from "./components/ui/ui";
@@ -112,7 +112,7 @@ export default function App() {
 	const [selectedWsId, setSelectedWsId] = useState("");
 
 	// collections
-	const [progress, setProgress] = useState([]);
+        const [projects, setProjects] = useState([]);
 	const [goals, setGoals] = useState([]);
 	const [people, setPeople] = useState([]);
 
@@ -149,14 +149,14 @@ export default function App() {
 	// subscribe to subcollections for selected workspace
 	useEffect(() => {
 		if (!selectedWsId) {
-		setProgress([]); setGoals([]); setPeople([]);
+                setProjects([]); setGoals([]); setPeople([]);
 		return;
 		}
 		const base = doc(db, "workspaces", selectedWsId);
 
-		const unsub1 = onSnapshot(collection(base, "progress"), (snap) =>
-		setProgress(snap.docs.map((d) => ({ id: d.id, ...d.data() })))
-		);
+                const unsub1 = onSnapshot(collection(base, "projects"), (snap) =>
+                setProjects(snap.docs.map((d) => ({ id: d.id, ...d.data() })))
+                );
 		const unsub2 = onSnapshot(collection(base, "goals"), (snap) =>
 		setGoals(snap.docs.map((d) => ({ id: d.id, ...d.data() })))
 		);
@@ -203,11 +203,11 @@ export default function App() {
                 }
         }
 
-        async function addGoalToProgress(progressId, goal) {
+        async function addGoalToProject(projectId, goal) {
                 const id = await addItem("goals", goal);
                 if (!id) return;
-                const current = progress.find((p) => p.id === progressId)?.goalIds || [];
-                updateItem("progress", progressId, { goalIds: [...current, id] });
+                const current = projects.find((p) => p.id === projectId)?.goalIds || [];
+                updateItem("projects", projectId, { goalIds: [...current, id] });
         }
 
 	// Workspace operations
@@ -293,8 +293,8 @@ export default function App() {
 		updateItem(col, id, patch);
 	}, 600);
 
-	const [pending, setPending] = useState({ progress: {}, goals: {} });
-	const [dragging, setDragging] = useState({ progress: {}, goals: {} });
+        const [pending, setPending] = useState({ projects: {}, goals: {} });
+        const [dragging, setDragging] = useState({ projects: {}, goals: {} });
 
 	const setPendingValue = useCallback((col, id, value) => {
 		setPending((p) => ({ ...p, [col]: { ...p[col], [id]: value } }));
@@ -310,7 +310,7 @@ export default function App() {
 		setDragging((d) => ({ ...d, [col]: { ...d[col], [id]: val } }));
 	}, []);
 
-	// Build a goals index for derived progress
+        // Build a goals index for derived project percent
 	const goalsById = useMemo(() => {
 		const m = Object.create(null);
 		for (const g of goals) m[g.id] = g;
@@ -324,16 +324,16 @@ export default function App() {
 		return Math.round(sum / arr.length);
 	}
 
-	const commitSlider = useCallback((type, item, liveValue) => {
-		const col = type;
-		const id = item.id;
-		const pendingValue = pending[type]?.[id];
-		const finalValue = pendingValue ?? liveValue ?? 0;
-		if (type === "progress") debouncedPersist("progress", id, { value: Number(finalValue) });
-		if (type === "goals") debouncedPersist("goals", id, { percent: Number(finalValue) });
-		clearPendingValue(type, id);
-		setDraggingFlag(type, id, false);
-	}, [pending, debouncedPersist, clearPendingValue, setDraggingFlag]);
+        const commitSlider = useCallback((type, item, liveValue) => {
+                const col = type;
+                const id = item.id;
+                const pendingValue = pending[type]?.[id];
+                const finalValue = pendingValue ?? liveValue ?? 0;
+                if (type === "projects") debouncedPersist("projects", id, { percent: Number(finalValue) });
+                if (type === "goals") debouncedPersist("goals", id, { percent: Number(finalValue) });
+                clearPendingValue(type, id);
+                setDraggingFlag(type, id, false);
+        }, [pending, debouncedPersist, clearPendingValue, setDraggingFlag]);
 
         return (
                 <div className={`app palette-${paletteKey}`}>
@@ -354,20 +354,20 @@ export default function App() {
                         />
 
                         <div className="grid-wrap">
-                        <ProgressOverview
+                        <ProjectsOverview
                                 paletteKey={paletteKey}
-                                data={progress}
+                                data={projects}
                                 goals={goals}
-                                onAdd={(item) => addItem("progress", item)}
-                                onUpdate={(id, patch) => updateItem("progress", id, patch)}
-                                onDelete={(id) => deleteItem("progress", id)}
+                                onAdd={(item) => addItem("projects", item)}
+                                onUpdate={(id, patch) => updateItem("projects", id, patch)}
+                                onDelete={(id) => deleteItem("projects", id)}
                                 readOnly={readOnly}
                                 computeDerivedPercent={computeDerivedPercent}
                                 pending={pending}
                                 setPendingValue={setPendingValue}
                                 setDraggingFlag={setDraggingFlag}
                                 commitSlider={commitSlider}
-                                onAddGoal={addGoalToProgress}
+                                onAddGoal={addGoalToProject}
                         />
                         <GoalsOverview
                                 paletteKey={paletteKey}

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -6,7 +6,7 @@ import "./header.css";
 export default function Header({ paletteKey, setPaletteKey, user, auth, provider }) {
   return (
     <div className="header">
-      <h2 className="header-title">Progress Tracker</h2>
+      <h2 className="header-title">Project Tracker</h2>
       <div className="header-controls">
         <AuthPanel user={user} auth={auth} provider={provider} />
         <label className="theme-label">Theme</label>

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -10,7 +10,7 @@
   border-bottom: 1px dashed var(--accent);
 }
 
-.list-row.progress,
+.list-row.projects,
 .list-row.goals {
   grid-template-columns: 1fr minmax(180px, 1fr) auto;
 }

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -27,16 +27,16 @@ export default function List({
       {!data.length && <div className="list-empty">No items</div>}
 
       {data.map((item) => {
-        const isProgress = type === "progress";
+        const isProjects = type === "projects";
         const isGoals = type === "goals";
         const isPeople = type === "people";
 
-        const colKey = isProgress ? "progress" : isGoals ? "goals" : null;
-        const linkedIds = isProgress ? (item.goalIds || []) : [];
-        const autoFromGoals = isProgress ? (item.auto ?? false) : false;
-        const derived = isProgress ? computeDerivedPercent(linkedIds) : 0;
-        const baseLive = isProgress ? (item.value ?? 0) : isGoals ? (item.percent ?? 0) : 0;
-        const liveValue = isProgress && autoFromGoals && linkedIds.length ? derived : baseLive;
+        const colKey = isProjects ? "projects" : isGoals ? "goals" : null;
+        const linkedIds = isProjects ? (item.goalIds || []) : [];
+        const autoFromGoals = isProjects ? (item.auto ?? false) : false;
+        const derived = isProjects ? computeDerivedPercent(linkedIds) : 0;
+        const baseLive = isProjects ? (item.percent ?? 0) : isGoals ? (item.percent ?? 0) : 0;
+        const liveValue = isProjects && autoFromGoals && linkedIds.length ? derived : baseLive;
         const pendingValue = colKey ? pending[colKey][item.id] : undefined;
         const shownValue = pendingValue !== undefined ? pendingValue : liveValue;
 
@@ -45,21 +45,21 @@ export default function List({
             key={item.id}
             className={`list-row ${type}`}
           >
-            {isProgress && (
+            {isProjects && (
               <>
-                <span>{item.label}</span>
+                <span>{item.name}</span>
                 <input
                   type="range"
                   min={0}
                   max={100}
                   step={1}
                   value={shownValue}
-                  onChange={(e) => setPendingValue("progress", item.id, Number(e.target.value))}
-                  onMouseDown={() => setDraggingFlag("progress", item.id, true)}
-                  onTouchStart={() => setDraggingFlag("progress", item.id, true)}
-                  onMouseUp={() => commitSlider("progress", item, liveValue)}
-                  onTouchEnd={() => commitSlider("progress", item, liveValue)}
-                  onBlur={() => commitSlider("progress", item, liveValue)}
+                  onChange={(e) => setPendingValue("projects", item.id, Number(e.target.value))}
+                  onMouseDown={() => setDraggingFlag("projects", item.id, true)}
+                  onTouchStart={() => setDraggingFlag("projects", item.id, true)}
+                  onMouseUp={() => commitSlider("projects", item, liveValue)}
+                  onTouchEnd={() => commitSlider("projects", item, liveValue)}
+                  onBlur={() => commitSlider("projects", item, liveValue)}
                   disabled={readOnly || (autoFromGoals && linkedIds.length > 0)}
                 />
                 <div className="list-value">
@@ -162,7 +162,7 @@ export default function List({
       {!readOnly && (
         <AddRow
           type={type}
-          placeholder={type === "people" ? "Add a person/project" : type === "goals" ? "Add a goal" : "Add a progress item"}
+          placeholder={type === "people" ? "Add a person/project" : type === "goals" ? "Add a goal" : "Add a project"}
           disabled={readOnly}
           onAdd={onAdd}
         />

--- a/src/components/progress-overview/progress-overview.jsx
+++ b/src/components/progress-overview/progress-overview.jsx
@@ -1,6 +1,0 @@
-import React from "react";
-import List from "../list/list";
-
-export default function ProgressOverview(props) {
-  return <List title="Track Progress" type="progress" {...props} />;
-}

--- a/src/components/projects-overview/projects-overview.jsx
+++ b/src/components/projects-overview/projects-overview.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import List from "../list/list";
+
+export default function ProjectsOverview(props) {
+  return <List title="Projects" type="projects" {...props} />;
+}

--- a/src/components/ui/ui.jsx
+++ b/src/components/ui/ui.jsx
@@ -33,7 +33,7 @@ export function AddRow({ type, onAdd, disabled, placeholder }) {
     const v = text.trim();
     if (!v) return;
     if (type === "people") onAdd({ name: v, status: "watching" });
-    if (type === "progress") onAdd({ label: v, value: 0, goalIds: [], auto: false });
+    if (type === "projects") onAdd({ name: v, percent: 0, goalIds: [], auto: false });
     if (type === "goals") onAdd({ title: v, percent: 0 });
     setText("");
   };


### PR DESCRIPTION
## Summary
- Replace ProgressOverview with ProjectsOverview and rename related state to `projects`
- Adjust list and AddRow components to manage `projects` items with `name`/`percent`
- Update user-facing copy and styles from progress to projects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a8ccfb7e88832696c4ae93887575d3