### PR TITLE
Add router-based workspace pages with theme persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "firebase": "^10.12.5",
         "framer-motion": "^10.18.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -1503,6 +1504,15 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3305,6 +3315,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "firebase": "^10.12.5",
     "framer-motion": "^10.18.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/App.css
+++ b/src/App.css
@@ -1,103 +1,115 @@
 .app {
-	min-height: 100vh;
-	background: var(--bg);
-	color: var(--text);
+        min-height: 100vh;
+        background: var(--bg);
+        color: var(--text);
 }
 
 .container {
-	max-width: 1200px;
-	margin: 0 auto;
-	padding: 24px;
-	display: flex;
-	flex-direction: column;
-	gap: 24px;
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
 }
 
 .banner {
-	padding: 12px;
-	border-radius: 10px;
-	border: 1px solid var(--accent);
-	background: var(--accent-subtle);
-	color: var(--text);
+        padding: 12px;
+        border-radius: 10px;
+        border: 1px solid var(--accent);
+        background: var(--accent-subtle);
+        color: var(--text);
 }
 
 .grid-wrap {
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 24px;
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 24px;
 }
 
 @media (max-width: 1100px) {
-	.grid-wrap {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
+        .grid-wrap {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
 }
 
 @media (max-width: 760px) {
-	.grid-wrap {
-		grid-template-columns: 1fr;
-	}
+        .grid-wrap {
+                grid-template-columns: 1fr;
+        }
 }
 
 .palette-info {
-	opacity: 0.7;
+        opacity: 0.7;
 }
 
 .palette-info span {
-	color: var(--accent);
+        color: var(--accent);
 }
 
 .workspace-bar {
-	display: grid;
-	grid-template-columns: 1fr auto auto;
-	gap: 8px;
-	align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
 }
 
 .workspace-create {
-	display: grid;
-	grid-template-columns: 1fr auto;
-	gap: 8px;
-	margin-top: 10px;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 8px;
+        margin-top: 10px;
 }
 
-.workspace-bar-select,
+.workspace-link {
+        color: var(--text);
+        text-decoration: none;
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 6px 8px;
+}
+
+.workspace-link.active {
+        background: var(--accent);
+        color: #fff;
+}
+
 .workspace-bar-input {
-	background: transparent;
-	color: var(--text);
-	border: 1px solid var(--accent);
-	border-radius: 8px;
-	padding: 6px 8px;
+        background: transparent;
+        color: var(--text);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 6px 8px;
 }
 
 .muted {
-	opacity: 0.6;
+        opacity: 0.6;
 }
 
 .accent {
-	color: var(--accent);
+        color: var(--accent);
 }
 
 .palette-royalViolet {
-	--bg: #1b1b2f;
-	--card: #2c2c3e;
-	--text: #f1f1f8;
-	--accent: #9d4edd;
-	--accent-subtle: #c77dff;
+        --bg: #1b1b2f;
+        --card: #2c2c3e;
+        --text: #f1f1f8;
+        --accent: #9d4edd;
+        --accent-subtle: #c77dff;
 }
 
 .palette-coralSpark {
-	--bg: #202124;
-	--card: #2f3136;
-	--text: #eeeeee;
-	--accent: #ff6b6b;
-	--accent-subtle: #ff9f80;
+        --bg: #202124;
+        --card: #2f3136;
+        --text: #eeeeee;
+        --accent: #ff6b6b;
+        --accent-subtle: #ff9f80;
 }
 
 .palette-neonCyan {
-	--bg: #0d1b2a;
-	--card: #1b263b;
-	--text: #e0e1dd;
-	--accent: #00b4d8;
-	--accent-subtle: #90e0ef;
+        --bg: #0d1b2a;
+        --card: #1b263b;
+        --text: #e0e1dd;
+        --accent: #00b4d8;
+        --accent-subtle: #90e0ef;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,488 +1,255 @@
-import React, {
-	useEffect,
-	useRef,
-	useState,
-	useCallback,
-	useMemo,
-} from "react";
-import { initializeApp } from "firebase/app";
-import { getAuth, onAuthStateChanged, GoogleAuthProvider } from "firebase/auth";
+import React, { useEffect, useState } from "react";
+import { onAuthStateChanged } from "firebase/auth";
 import {
-	getFirestore,
-	collection,
-	addDoc,
-	updateDoc,
-	deleteDoc,
-	doc,
-	onSnapshot,
-	serverTimestamp,
-	query,
-	where,
-	orderBy,
-	getDocs,
+        collection,
+        addDoc,
+        updateDoc,
+        deleteDoc,
+        doc,
+        onSnapshot,
+        serverTimestamp,
+        query,
+        where,
+        getDocs,
 } from "firebase/firestore";
-import { firebaseConfig } from "./firebase-config";
+import { Link, Routes, Route, useLocation, useNavigate } from "react-router-dom";
+import { db, auth, provider } from "./firebase";
 import Header from "./components/header/header";
-import ProjectsOverview from "./components/projects-overview/projects-overview";
-import GoalsOverview from "./components/goals-overview/goals-overview";
-import PeopleOverview from "./components/people-overview/people-overview";
-import { PALETTES, Card, Button } from "./components/ui/ui";
+import WorkspacePage from "./workspace-page";
+import { Card, Button } from "./components/ui/ui";
 import "./App.css";
 
-// ========== Firebase ==========
-const fbApp = initializeApp(firebaseConfig);
-const db = getFirestore(fbApp);
-const auth = getAuth(fbApp);
-const provider = new GoogleAuthProvider();
+function WorkspaceNav({ workspaces, currentWsId, createWorkspace, deleteWorkspace, resetLocal, testConnection }) {
+        const [name, setName] = useState("");
+        const navigate = useNavigate();
+        return (
+                <Card title="Workspaces" right={null}>
+                        <div className="workspace-bar">
+                                {workspaces.length === 0 && <span>No workspaces yet</span>}
+                                {workspaces.map((w) => (
+                                        <Link
+                                                key={w.id}
+                                                to={`/workspace/${w.id}`}
+                                                className={w.id === currentWsId ? "workspace-link active" : "workspace-link"}
+                                        >
+                                                {w.name || "Untitled"}
+                                        </Link>
+                                ))}
+                                <Button subtle onClick={resetLocal}>Reset local cache</Button>
+                                <Button onClick={testConnection}>Test connection</Button>
+                                <Button
+                                        onClick={() => {
+                                                if (
+                                                        currentWsId &&
+                                                        window.confirm(
+                                                                "Delete this workspace? This will remove all data.",
+                                                        )
+                                                ) {
+                                                        deleteWorkspace(currentWsId);
+                                                }
+                                        }}
+                                        disabled={!currentWsId}
+                                >
+                                        Delete workspace
+                                </Button>
+                        </div>
 
-// ========== Utilities ==========
-function useDebouncedCallback(fn, delay = 600) {
-	const fnRef = useRef(fn);
-	const timer = useRef(null);
-	useEffect(() => {
-		fnRef.current = fn;
-	}, [fn]);
-	useEffect(() => () => timer.current && clearTimeout(timer.current), []);
-	return useCallback(
-		(...args) => {
-			if (timer.current) clearTimeout(timer.current);
-			timer.current = setTimeout(() => fnRef.current(...args), delay);
-		},
-		[delay],
-	);
+                        <div className="workspace-create">
+                                <input
+                                        className="workspace-bar-input"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        placeholder="New workspace name"
+                                />
+                                <Button
+                                        onClick={async () => {
+                                                const n = name.trim();
+                                                if (!n) return;
+                                                const id = await createWorkspace(n);
+                                                if (id) navigate(`/workspace/${id}`);
+                                                setName("");
+                                        }}
+                                >
+                                        Create
+                                </Button>
+                        </div>
+                </Card>
+        );
 }
 
-function WorkspaceBar({
-	workspaces,
-	selectedWsId,
-	setSelectedWsId,
-	createWorkspace,
-	deleteWorkspace,
-	resetLocal,
-	testConnection,
-}) {
-	const [name, setName] = useState("");
-	return (
-		<Card title="Workspaces" right={null}>
-			<div className="workspace-bar">
-				<select
-					className="workspace-bar-select"
-					value={selectedWsId || ""}
-					onChange={(e) => setSelectedWsId(e.target.value)}
-				>
-					{workspaces.length === 0 && (
-						<option value="">No workspaces yet</option>
-					)}
-					{workspaces.map((w) => (
-						<option key={w.id} value={w.id}>
-							{w.name || "Untitled"}
-						</option>
-					))}
-				</select>
-				<Button subtle onClick={resetLocal}>
-					Reset local cache
-				</Button>
-				<Button onClick={testConnection}>Test connection</Button>
-				<Button
-					onClick={() => {
-						if (
-							selectedWsId &&
-							window.confirm(
-								"Delete this workspace? This will remove all data.",
-							)
-						) {
-							deleteWorkspace(selectedWsId);
-						}
-					}}
-					disabled={!selectedWsId}
-				>
-					Delete workspace
-				</Button>
-			</div>
-
-			<div className="workspace-create">
-				<input
-					className="workspace-bar-input"
-					value={name}
-					onChange={(e) => setName(e.target.value)}
-					placeholder="New workspace name"
-				/>
-				<Button
-					onClick={async () => {
-						const n = name.trim();
-						if (!n) return;
-						const id = await createWorkspace(n);
-						if (id) setSelectedWsId(id);
-						setName("");
-					}}
-				>
-					Create
-				</Button>
-			</div>
-		</Card>
-	);
-}
-
-// ========== Main App ==========
 export default function App() {
-	const [paletteKey, setPaletteKey] = useState("royalViolet");
+        const [paletteKey, setPaletteKey] = useState("royalViolet");
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+                const unsub = onAuthStateChanged(auth, setUser);
+                return () => unsub();
+        }, []);
 
-	const [user, setUser] = useState(null);
-	useEffect(() => {
-		const unsub = onAuthStateChanged(auth, setUser);
-		return () => unsub();
-	}, []);
+        const [banner, setBanner] = useState("");
+        const [workspaces, setWorkspaces] = useState([]);
 
-	const [banner, setBanner] = useState("");
+        const location = useLocation();
+        const navigate = useNavigate();
+        const currentWsId = location.pathname.startsWith("/workspace/")
+                ? location.pathname.split("/")[2]
+                : "";
 
-	// workspaces
-	const [workspaces, setWorkspaces] = useState([]);
-	const [selectedWsId, setSelectedWsId] = useState("");
+        useEffect(() => {
+                if (!user) {
+                        setWorkspaces([]);
+                        return;
+                }
+                const q = query(
+                        collection(db, "workspaces"),
+                        where("memberIds", "array-contains", user.uid),
+                );
+                const unsub = onSnapshot(
+                        q,
+                        (snap) => {
+                                const list = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+                                setWorkspaces(list);
+                                if (!currentWsId && list[0]) navigate(`/workspace/${list[0].id}`);
+                        },
+                        (err) => {
+                                console.error("workspace load failed", err);
+                                setBanner(`Load workspaces failed: ${err.message}`);
+                        },
+                );
+                return () => unsub();
+        }, [user, currentWsId, navigate]);
 
-	// collections
-	const [projects, setProjects] = useState([]);
-	const [goals, setGoals] = useState([]);
-	const [people, setPeople] = useState([]);
+        async function createWorkspace(name) {
+                if (!auth.currentUser) {
+                        setBanner("Please sign in to create a workspace.");
+                        return "";
+                }
+                const tempId = "temp-" + Math.random().toString(36).slice(2);
+                try {
+                        const uid = auth.currentUser.uid;
+                        setWorkspaces((prev) => [
+                                ...prev,
+                                {
+                                        id: tempId,
+                                        name,
+                                        members: { [uid]: "owner" },
+                                        memberIds: [uid],
+                                        createdAt: new Date(),
+                                        paletteKey: "royalViolet",
+                                },
+                        ]);
+                        const d = await addDoc(collection(db, "workspaces"), {
+                                name,
+                                createdAt: serverTimestamp(),
+                                createdBy: uid,
+                                members: { [uid]: "owner" },
+                                memberIds: [uid],
+                                paletteKey: "royalViolet",
+                        });
+                        setWorkspaces((prev) =>
+                                prev.map((w) => (w.id === tempId ? { ...w, id: d.id } : w)),
+                        );
+                        navigate(`/workspace/${d.id}`);
+                        setBanner(`Created workspace “${name}”.`);
+                        return d.id;
+                } catch (err) {
+                        setWorkspaces((prev) => prev.filter((w) => w.id !== tempId));
+                        setBanner(`Create workspace failed: ${err.message}`);
+                        return "";
+                }
+        }
 
-	const readOnly = !selectedWsId;
+        async function deleteWorkspace(id) {
+                try {
+                        const wsRef = doc(db, "workspaces", id);
+                        const subcols = ["projects", "goals", "people"];
+                        for (const c of subcols) {
+                                const snap = await getDocs(collection(wsRef, c));
+                                await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
+                        }
+                        await deleteDoc(wsRef);
+                        if (currentWsId === id) {
+                                const remaining = workspaces.find((w) => w.id !== id);
+                                if (remaining) navigate(`/workspace/${remaining.id}`);
+                                else navigate("/");
+                        }
+                        setBanner("Workspace deleted.");
+                } catch (err) {
+                        setBanner(`Delete workspace failed: ${err.message}`);
+                }
+        }
 
-	// load workspaces for the current user
-	useEffect(() => {
-		if (!user) {
-			setWorkspaces([]);
-			setSelectedWsId("");
-			return;
-		}
+        function resetLocal() {
+                setBanner("Local cache cleared.");
+                if (currentWsId) {
+                        navigate("/");
+                        setTimeout(() => navigate(`/workspace/${currentWsId}`), 0);
+                }
+        }
 
-		const q = query(
-			collection(db, "workspaces"),
-			where("memberIds", "array-contains", user.uid),
-			// NOTE: removed orderBy("createdAt") for now to avoid composite index error.
-			// After this works, add it back and follow the console link to create the index.
-		);
-		const unsub = onSnapshot(
-			q,
-			(snap) => {
-				const list = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-				setWorkspaces(list);
-				if (!selectedWsId && list[0]) setSelectedWsId(list[0].id);
-			},
-			(err) => {
-				console.error("workspace load failed", err);
-				setBanner(`Load workspaces failed: ${err.message}`);
-			},
-		);
-		return () => unsub();
-	}, [user]);
+        async function testConnection() {
+                if (!currentWsId) {
+                        setBanner("No workspace selected.");
+                        return;
+                }
+                try {
+                        const base = doc(db, "workspaces", currentWsId);
+                        const pingCol = collection(base, "__ping");
+                        const added = await addDoc(pingCol, { t: Date.now() });
+                        await deleteDoc(doc(pingCol, added.id));
+                        setBanner("✅ Connection OK: rules permit read/write in this workspace.");
+                } catch (err) {
+                        setBanner(`❌ Test failed: ${err.message}`);
+                }
+        }
 
-	// subscribe to subcollections for selected workspace
-	useEffect(() => {
-		if (!selectedWsId) {
-			setProjects([]);
-			setGoals([]);
-			setPeople([]);
-			return;
-		}
-		const base = doc(db, "workspaces", selectedWsId);
+        const handlePaletteChange = async (key) => {
+                setPaletteKey(key);
+                if (currentWsId) {
+                        try {
+                                await updateDoc(doc(db, "workspaces", currentWsId), { paletteKey: key });
+                        } catch (err) {
+                                setBanner(`Update theme failed: ${err.message}`);
+                        }
+                }
+        };
 
-		const unsub1 = onSnapshot(collection(base, "projects"), (snap) =>
-			setProjects(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
-		);
-		const unsub2 = onSnapshot(collection(base, "goals"), (snap) =>
-			setGoals(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
-		);
-		const unsub3 = onSnapshot(collection(base, "people"), (snap) =>
-			setPeople(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
-		);
+        return (
+                <div className={`app palette-${paletteKey}`}>
+                        <div className="container">
+                                <Header
+                                        paletteKey={paletteKey}
+                                        setPaletteKey={handlePaletteChange}
+                                        user={user}
+                                        auth={auth}
+                                        provider={provider}
+                                />
 
-		return () => {
-			unsub1();
-			unsub2();
-			unsub3();
-		};
-	}, [selectedWsId]);
+                                {banner && <div className="banner">{banner}</div>}
 
-	// helpers
-	const getColRef = (colName) => {
-		if (!selectedWsId) return null;
-		return collection(db, "workspaces", selectedWsId, colName);
-	};
+                                <WorkspaceNav
+                                        workspaces={workspaces}
+                                        currentWsId={currentWsId}
+                                        createWorkspace={createWorkspace}
+                                        deleteWorkspace={deleteWorkspace}
+                                        resetLocal={resetLocal}
+                                        testConnection={testConnection}
+                                />
 
-	async function addItem(colName, item) {
-		const ref = getColRef(colName);
-		if (!ref) {
-			setBanner("No workspace selected.");
-			return "";
-		}
-		try {
-			const d = await addDoc(ref, { ...item, createdAt: serverTimestamp() });
-			return d.id;
-		} catch (err) {
-			setBanner(`Add failed: ${err.message}`);
-			return "";
-		}
-	}
-
-	async function updateItem(colName, id, patch) {
-		const ref = getColRef(colName);
-		if (!ref) {
-			setBanner("No workspace selected.");
-			return;
-		}
-		try {
-			await updateDoc(doc(ref, id), patch);
-		} catch (err) {
-			setBanner(`Update failed: ${err.message}`);
-		}
-	}
-	async function deleteItem(colName, id) {
-		const ref = getColRef(colName);
-		if (!ref) {
-			setBanner("No workspace selected.");
-			return;
-		}
-		try {
-			await deleteDoc(doc(ref, id));
-		} catch (err) {
-			setBanner(`Delete failed: ${err.message}`);
-		}
-	}
-
-	async function addGoalToProject(projectId, goal) {
-		const id = await addItem("goals", goal);
-		if (!id) return;
-		const current = projects.find((p) => p.id === projectId)?.goalIds || [];
-		updateItem("projects", projectId, { goalIds: [...current, id] });
-	}
-
-	// Workspace operations
-	async function createWorkspace(name) {
-		if (!auth.currentUser) {
-			setBanner("Please sign in to create a workspace.");
-			return "";
-		}
-		// prepare temp id outside try/catch so we can clean it up on failure
-		const tempId = "temp-" + Math.random().toString(36).slice(2);
-		try {
-			const uid = auth.currentUser.uid;
-			const wsRef = collection(db, "workspaces");
-
-			// Optimistically add a temporary option so the <select> isn't blank
-			setWorkspaces((prev) => [
-				...prev,
-				{
-					id: tempId,
-					name,
-					members: { [uid]: "owner" },
-					memberIds: [uid],
-					createdAt: new Date(),
-				},
-			]);
-			setSelectedWsId(tempId);
-
-			// Write a workspace that satisfies your rules
-			const d = await addDoc(collection(db, "workspaces"), {
-				name,
-				createdAt: serverTimestamp(),
-				createdBy: uid,
-				members: { [uid]: "owner" },
-				memberIds: [uid],
-			});
-
-			// Switch the select to the real id and replace temp entry
-			setSelectedWsId(d.id);
-			setWorkspaces((prev) =>
-				prev.map((w) => (w.id === tempId ? { ...w, id: d.id } : w)),
-			);
-			setBanner(`Created workspace “${name}”.`);
-			return d.id;
-		} catch (err) {
-			// Remove the temporary entry on failure
-			setWorkspaces((prev) => prev.filter((w) => w.id !== tempId));
-			setBanner(`Create workspace failed: ${err.message}`);
-			return "";
-		}
-	}
-
-	async function deleteWorkspace(id) {
-		try {
-			const wsRef = doc(db, "workspaces", id);
-			const subcols = ["projects", "goals", "people"];
-			for (const c of subcols) {
-				const snap = await getDocs(collection(wsRef, c));
-				await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
-			}
-			await deleteDoc(wsRef);
-			if (selectedWsId === id) setSelectedWsId("");
-			setBanner("Workspace deleted.");
-		} catch (err) {
-			setBanner(`Delete workspace failed: ${err.message}`);
-		}
-	}
-
-	async function updateWorkspaceMembers(id, members) {
-		try {
-			await updateDoc(doc(db, "workspaces", id), {
-				members,
-				memberIds: Object.keys(members),
-			});
-		} catch (err) {
-			setBanner(`Update members failed: ${err.message}`);
-		}
-	}
-
-	function resetLocal() {
-		setBanner("Local cache cleared.");
-		setSelectedWsId((cur) => {
-			const next = cur;
-			setSelectedWsId("");
-			setTimeout(() => setSelectedWsId(next), 0);
-			return cur;
-		});
-	}
-
-	// Test connection (permissions probe within selected workspace)
-	async function testConnection() {
-		if (!selectedWsId) {
-			setBanner("No workspace selected.");
-			return;
-		}
-		try {
-			const base = doc(db, "workspaces", selectedWsId);
-			const pingCol = collection(base, "__ping");
-			const added = await addDoc(pingCol, { t: Date.now() });
-			await deleteDoc(doc(pingCol, added.id));
-			setBanner("✅ Connection OK: rules permit read/write in this workspace.");
-		} catch (err) {
-			setBanner(`❌ Test failed: ${err.message}`);
-		}
-	}
-
-	// Debounced slider persist + optimistic values (simplified and robust)
-	const debouncedPersist = useDebouncedCallback((col, id, patch) => {
-		updateItem(col, id, patch);
-	}, 600);
-
-	const [pending, setPending] = useState({ projects: {}, goals: {} });
-	const [dragging, setDragging] = useState({ projects: {}, goals: {} });
-
-	const setPendingValue = useCallback((col, id, value) => {
-		setPending((p) => ({ ...p, [col]: { ...p[col], [id]: value } }));
-	}, []);
-
-	const clearPendingValue = useCallback((col, id) => {
-		setPending((p) => {
-			const copy = { ...p[col] };
-			delete copy[id];
-			return { ...p, [col]: copy };
-		});
-	}, []);
-
-	const setDraggingFlag = useCallback((col, id, val) => {
-		setDragging((d) => ({ ...d, [col]: { ...d[col], [id]: val } }));
-	}, []);
-
-	// Build a goals index for derived project percent
-	const goalsById = useMemo(() => {
-		const m = Object.create(null);
-		for (const g of goals) m[g.id] = g;
-		return m;
-	}, [goals]);
-
-	function computeDerivedPercent(goalIds = []) {
-		const arr = goalIds.map((id) => goalsById[id]?.percent ?? 0);
-		if (!arr.length) return 0;
-		const sum = arr.reduce((a, b) => a + b, 0);
-		return Math.round(sum / arr.length);
-	}
-
-	const commitSlider = useCallback(
-		(type, item, liveValue) => {
-			const col = type;
-			const id = item.id;
-			const pendingValue = pending[type]?.[id];
-			const finalValue = pendingValue ?? liveValue ?? 0;
-			if (type === "projects")
-				debouncedPersist("projects", id, { percent: Number(finalValue) });
-			if (type === "goals")
-				debouncedPersist("goals", id, { percent: Number(finalValue) });
-			clearPendingValue(type, id);
-			setDraggingFlag(type, id, false);
-		},
-		[pending, debouncedPersist, clearPendingValue, setDraggingFlag],
-	);
-
-	return (
-		<div className={`app palette-${paletteKey}`}>
-			<div className="container">
-				<Header
-					paletteKey={paletteKey}
-					setPaletteKey={setPaletteKey}
-					user={user}
-					auth={auth}
-					provider={provider}
-				/>
-
-				{banner && <div className="banner">{banner}</div>}
-
-				<WorkspaceBar
-					workspaces={workspaces}
-					selectedWsId={selectedWsId}
-					setSelectedWsId={setSelectedWsId}
-					createWorkspace={createWorkspace}
-					deleteWorkspace={deleteWorkspace}
-					resetLocal={resetLocal}
-					testConnection={testConnection}
-				/>
-
-				<div className="grid-wrap">
-					<ProjectsOverview
-						paletteKey={paletteKey}
-						data={projects}
-						goals={goals}
-						onAdd={(item) => addItem("projects", item)}
-						onUpdate={(id, patch) => updateItem("projects", id, patch)}
-						onDelete={(id) => deleteItem("projects", id)}
-						readOnly={readOnly}
-						computeDerivedPercent={computeDerivedPercent}
-						pending={pending}
-						setPendingValue={setPendingValue}
-						setDraggingFlag={setDraggingFlag}
-						commitSlider={commitSlider}
-						onAddGoal={addGoalToProject}
-					/>
-					<GoalsOverview
-						paletteKey={paletteKey}
-						data={goals}
-						onAdd={(item) => addItem("goals", item)}
-						onUpdate={(id, patch) => updateItem("goals", id, patch)}
-						onDelete={(id) => deleteItem("goals", id)}
-						readOnly={readOnly}
-						pending={pending}
-						setPendingValue={setPendingValue}
-						setDraggingFlag={setDraggingFlag}
-						commitSlider={commitSlider}
-					/>
-					<PeopleOverview
-						paletteKey={paletteKey}
-						data={people}
-						onAdd={(item) => addItem("people", item)}
-						onUpdate={(id, patch) => updateItem("people", id, patch)}
-						onDelete={(id) => deleteItem("people", id)}
-						readOnly={readOnly}
-						pending={pending}
-						setPendingValue={setPendingValue}
-						setDraggingFlag={setDraggingFlag}
-						commitSlider={commitSlider}
-					/>
-				</div>
-
-				<div className="palette-info">
-					<small>
-						Palette: <span>{PALETTES[paletteKey].name}</span>
-					</small>
-				</div>
-			</div>
-		</div>
-	);
+                                <Routes>
+                                        <Route
+                                                path="/workspace/:id"
+                                                element={
+                                                        <WorkspacePage
+                                                                paletteKey={paletteKey}
+                                                                setPaletteKey={setPaletteKey}
+                                                                setBanner={setBanner}
+                                                        />
+                                                }
+                                        />
+                                        <Route path="*" element={<div>Select a workspace</div>} />
+                                </Routes>
+                        </div>
+                </div>
+        );
 }
+

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,10 @@
+import { initializeApp } from "firebase/app";
+import { getAuth, GoogleAuthProvider } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
+import { firebaseConfig } from "./firebase-config";
+
+const fbApp = initializeApp(firebaseConfig);
+export const db = getFirestore(fbApp);
+export const auth = getAuth(fbApp);
+export const provider = new GoogleAuthProvider();
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
 import "./index.css";
 import { registerSW } from "./registerSW.js";
@@ -7,7 +8,9 @@ import { registerSW } from "./registerSW.js";
 registerSW();
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-	<React.StrictMode>
-		<App />
-	</React.StrictMode>,
+        <React.StrictMode>
+                <BrowserRouter>
+                        <App />
+                </BrowserRouter>
+        </React.StrictMode>,
 );

--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { useParams } from "react-router-dom";
+import {
+        collection,
+        addDoc,
+        updateDoc,
+        deleteDoc,
+        doc,
+        onSnapshot,
+        serverTimestamp,
+} from "firebase/firestore";
+import { db } from "./firebase";
+import ProjectsOverview from "./components/projects-overview/projects-overview";
+import GoalsOverview from "./components/goals-overview/goals-overview";
+import PeopleOverview from "./components/people-overview/people-overview";
+import { PALETTES } from "./components/ui/ui";
+
+function useDebouncedCallback(fn, delay = 600) {
+        const fnRef = useRef(fn);
+        const timer = useRef(null);
+        useEffect(() => {
+                fnRef.current = fn;
+        }, [fn]);
+        useEffect(() => () => timer.current && clearTimeout(timer.current), []);
+        return useCallback(
+                (...args) => {
+                        if (timer.current) clearTimeout(timer.current);
+                        timer.current = setTimeout(() => fnRef.current(...args), delay);
+                },
+                [delay],
+        );
+}
+
+export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) {
+        const { id: wsId } = useParams();
+        const [projects, setProjects] = useState([]);
+        const [goals, setGoals] = useState([]);
+        const [people, setPeople] = useState([]);
+
+        useEffect(() => {
+                if (!wsId) {
+                        setProjects([]);
+                        setGoals([]);
+                        setPeople([]);
+                        return;
+                }
+                const base = doc(db, "workspaces", wsId);
+                const unsubWs = onSnapshot(base, (snap) => {
+                        const data = snap.data();
+                        if (data?.paletteKey) setPaletteKey(data.paletteKey);
+                });
+                const unsub1 = onSnapshot(collection(base, "projects"), (snap) =>
+                        setProjects(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
+                );
+                const unsub2 = onSnapshot(collection(base, "goals"), (snap) =>
+                        setGoals(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
+                );
+                const unsub3 = onSnapshot(collection(base, "people"), (snap) =>
+                        setPeople(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
+                );
+                return () => {
+                        unsubWs();
+                        unsub1();
+                        unsub2();
+                        unsub3();
+                };
+        }, [wsId, setPaletteKey]);
+
+        const readOnly = !wsId;
+
+        const getColRef = (colName) => {
+                if (!wsId) return null;
+                return collection(db, "workspaces", wsId, colName);
+        };
+
+        async function addItem(colName, item) {
+                const ref = getColRef(colName);
+                if (!ref) {
+                        setBanner("No workspace selected.");
+                        return "";
+                }
+                try {
+                        const d = await addDoc(ref, { ...item, createdAt: serverTimestamp() });
+                        return d.id;
+                } catch (err) {
+                        setBanner(`Add failed: ${err.message}`);
+                        return "";
+                }
+        }
+
+        async function updateItem(colName, id, patch) {
+                const ref = getColRef(colName);
+                if (!ref) {
+                        setBanner("No workspace selected.");
+                        return;
+                }
+                try {
+                        await updateDoc(doc(ref, id), patch);
+                } catch (err) {
+                        setBanner(`Update failed: ${err.message}`);
+                }
+        }
+        async function deleteItem(colName, id) {
+                const ref = getColRef(colName);
+                if (!ref) {
+                        setBanner("No workspace selected.");
+                        return;
+                }
+                try {
+                        await deleteDoc(doc(ref, id));
+                } catch (err) {
+                        setBanner(`Delete failed: ${err.message}`);
+                }
+        }
+
+        async function addGoalToProject(projectId, goal) {
+                const id = await addItem("goals", goal);
+                if (!id) return;
+                const current = projects.find((p) => p.id === projectId)?.goalIds || [];
+                updateItem("projects", projectId, { goalIds: [...current, id] });
+        }
+
+        const debouncedPersist = useDebouncedCallback((col, id, patch) => {
+                updateItem(col, id, patch);
+        }, 600);
+
+        const [pending, setPending] = useState({ projects: {}, goals: {} });
+        const [dragging, setDragging] = useState({ projects: {}, goals: {} });
+
+        const setPendingValue = useCallback((col, id, value) => {
+                setPending((p) => ({ ...p, [col]: { ...p[col], [id]: value } }));
+        }, []);
+
+        const clearPendingValue = useCallback((col, id) => {
+                setPending((p) => {
+                        const copy = { ...p[col] };
+                        delete copy[id];
+                        return { ...p, [col]: copy };
+                });
+        }, []);
+
+        const setDraggingFlag = useCallback((col, id, val) => {
+                setDragging((d) => ({ ...d, [col]: { ...d[col], [id]: val } }));
+        }, []);
+
+        const goalsById = useMemo(() => {
+                const m = Object.create(null);
+                for (const g of goals) m[g.id] = g;
+                return m;
+        }, [goals]);
+
+        function computeDerivedPercent(goalIds = []) {
+                const arr = goalIds.map((id) => goalsById[id]?.percent ?? 0);
+                if (!arr.length) return 0;
+                const sum = arr.reduce((a, b) => a + b, 0);
+                return Math.round(sum / arr.length);
+        }
+
+        const commitSlider = useCallback(
+                (type, item, liveValue) => {
+                        const col = type;
+                        const id = item.id;
+                        const pendingValue = pending[type]?.[id];
+                        const finalValue = pendingValue ?? liveValue ?? 0;
+                        if (type === "projects")
+                                debouncedPersist("projects", id, { percent: Number(finalValue) });
+                        if (type === "goals")
+                                debouncedPersist("goals", id, { percent: Number(finalValue) });
+                        clearPendingValue(type, id);
+                        setDraggingFlag(type, id, false);
+                },
+                [pending, debouncedPersist, clearPendingValue, setDraggingFlag],
+        );
+
+        return (
+                <>
+                        <div className="grid-wrap">
+                                <ProjectsOverview
+                                        paletteKey={paletteKey}
+                                        data={projects}
+                                        goals={goals}
+                                        onAdd={(item) => addItem("projects", item)}
+                                        onUpdate={(id, patch) => updateItem("projects", id, patch)}
+                                        onDelete={(id) => deleteItem("projects", id)}
+                                        readOnly={readOnly}
+                                        computeDerivedPercent={computeDerivedPercent}
+                                        pending={pending}
+                                        setPendingValue={setPendingValue}
+                                        setDraggingFlag={setDraggingFlag}
+                                        commitSlider={commitSlider}
+                                        onAddGoal={addGoalToProject}
+                                />
+                                <GoalsOverview
+                                        paletteKey={paletteKey}
+                                        data={goals}
+                                        onAdd={(item) => addItem("goals", item)}
+                                        onUpdate={(id, patch) => updateItem("goals", id, patch)}
+                                        onDelete={(id) => deleteItem("goals", id)}
+                                        readOnly={readOnly}
+                                        pending={pending}
+                                        setPendingValue={setPendingValue}
+                                        setDraggingFlag={setDraggingFlag}
+                                        commitSlider={commitSlider}
+                                />
+                                <PeopleOverview
+                                        paletteKey={paletteKey}
+                                        data={people}
+                                        onAdd={(item) => addItem("people", item)}
+                                        onUpdate={(id, patch) => updateItem("people", id, patch)}
+                                        onDelete={(id) => deleteItem("people", id)}
+                                        readOnly={readOnly}
+                                        pending={pending}
+                                        setPendingValue={setPendingValue}
+                                        setDraggingFlag={setDraggingFlag}
+                                        commitSlider={commitSlider}
+                                />
+                        </div>
+
+                        <div className="palette-info">
+                                <small>
+                                        Palette: <span>{PALETTES[paletteKey].name}</span>
+                                </small>
+                        </div>
+                </>
+        );
+}
+


### PR DESCRIPTION
## Summary
- integrate React Router and link-based workspace navigation
- persist and load workspace theme palette per workspace
- render workspace projects via `/workspace/:id` routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d9a3d1048326a5d66c96effad42c