### PR TITLE
Refactor goals into project subcollections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,11 +161,16 @@ export default function App() {
         async function deleteWorkspace(id) {
                 try {
                         const wsRef = doc(db, "workspaces", id);
-                        const subcols = ["projects", "goals", "people"];
-                        for (const c of subcols) {
-                                const snap = await getDocs(collection(wsRef, c));
-                                await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
-                        }
+                        const projectSnap = await getDocs(collection(wsRef, "projects"));
+                        await Promise.all(
+                                projectSnap.docs.map(async (p) => {
+                                        const goalsSnap = await getDocs(collection(p.ref, "goals"));
+                                        await Promise.all(goalsSnap.docs.map((g) => deleteDoc(g.ref)));
+                                        await deleteDoc(p.ref);
+                                }),
+                        );
+                        const peopleSnap = await getDocs(collection(wsRef, "people"));
+                        await Promise.all(peopleSnap.docs.map((d) => deleteDoc(d.ref)));
                         await deleteDoc(wsRef);
                         if (currentWsId === id) {
                                 const remaining = workspaces.find((w) => w.id !== id);

--- a/src/components/goals-overview/goals-overview.jsx
+++ b/src/components/goals-overview/goals-overview.jsx
@@ -1,6 +1,0 @@
-import React from "react";
-import List from "../list/list";
-
-export default function GoalsOverview(props) {
-	return <List title="Goals" type="goals" {...props} />;
-}

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -3,11 +3,16 @@
 }
 
 .list-row {
-	display: grid;
-	gap: 12px;
-	align-items: center;
-	padding: 10px 0;
-	border-bottom: 1px dashed var(--accent);
+        display: grid;
+        gap: 12px;
+        align-items: center;
+        padding: 10px 0;
+        border-bottom: 1px dashed var(--accent);
+}
+
+.list-row.selected {
+        background: var(--accent-subtle);
+        color: #fff;
 }
 
 .list-row.projects,
@@ -43,22 +48,6 @@
 	display: flex;
 	align-items: center;
 	gap: 6px;
-}
-
-.link-goals-summary {
-	cursor: pointer;
-}
-
-.link-goals-list {
-	margin-top: 8px;
-	display: grid;
-	gap: 6px;
-}
-
-.link-goals-item {
-	display: flex;
-	align-items: center;
-	gap: 8px;
 }
 
 .status-select {

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -3,21 +3,21 @@ import { Card, AddRow } from "../ui/ui";
 import "./list.css";
 
 export default function List({
-	title,
-	type,
-	data,
-	onAdd,
-	onUpdate,
-	onDelete,
-	paletteKey,
-	readOnly,
-	goals = [],
-	computeDerivedPercent = () => 0,
-	pending,
-	setPendingValue,
-	setDraggingFlag,
-	commitSlider,
-	onAddGoal,
+        title,
+        type,
+        data,
+        onAdd,
+        onUpdate,
+        onDelete,
+        paletteKey,
+        readOnly,
+        computeDerivedPercent = () => ({ percent: 0, count: 0 }),
+        pending,
+        setPendingValue,
+        setDraggingFlag,
+        commitSlider,
+        onSelectItem,
+        selectedId,
 }) {
 	return (
 		<Card
@@ -31,27 +31,34 @@ export default function List({
 				const isGoals = type === "goals";
 				const isPeople = type === "people";
 
-				const colKey = isProjects ? "projects" : isGoals ? "goals" : null;
-				const linkedIds = isProjects ? item.goalIds || [] : [];
-				const autoFromGoals = isProjects ? (item.auto ?? false) : false;
-				const derived = isProjects ? computeDerivedPercent(linkedIds) : 0;
-				const baseLive = isProjects
-					? (item.percent ?? 0)
-					: isGoals
-						? (item.percent ?? 0)
-						: 0;
-				const liveValue =
-					isProjects && autoFromGoals && linkedIds.length ? derived : baseLive;
-				const pendingValue = colKey ? pending[colKey][item.id] : undefined;
-				const shownValue =
-					pendingValue !== undefined ? pendingValue : liveValue;
+                                const colKey = isProjects ? "projects" : isGoals ? "goals" : null;
+                                const autoFromGoals = isProjects ? (item.auto ?? false) : false;
+                                const { percent: derived, count: goalCount } = isProjects
+                                        ? computeDerivedPercent(item.id)
+                                        : { percent: 0, count: 0 };
+                                const baseLive = isProjects
+                                        ? (item.percent ?? 0)
+                                        : isGoals
+                                                ? (item.percent ?? 0)
+                                                : 0;
+                                const liveValue =
+                                        isProjects && autoFromGoals && goalCount ? derived : baseLive;
+                                const pendingValue = colKey ? pending[colKey][item.id] : undefined;
+                                const shownValue =
+                                        pendingValue !== undefined ? pendingValue : liveValue;
 
-				return (
-					<div key={item.id} className={`list-row ${type}`}>
-						{isProjects && (
-							<>
-								<span>{item.name}</span>
-								<input
+                                return (
+                                        <div
+                                                key={item.id}
+                                                className={`list-row ${type} ${
+                                                        selectedId === item.id ? "selected" : ""
+                                                }`}
+                                                onClick={() => onSelectItem && onSelectItem(item.id)}
+                                        >
+                                                {isProjects && (
+                                                        <>
+                                                                <span>{item.name}</span>
+                                                                <input
 									type="range"
 									min={0}
 									max={100}
@@ -67,77 +74,39 @@ export default function List({
 									onMouseUp={() => commitSlider("projects", item, liveValue)}
 									onTouchEnd={() => commitSlider("projects", item, liveValue)}
 									onBlur={() => commitSlider("projects", item, liveValue)}
-									disabled={readOnly || (autoFromGoals && linkedIds.length > 0)}
-								/>
-								<div className="list-actions">
-									<div className="list-value">
-										{autoFromGoals && linkedIds.length > 0
-											? `${derived}% (auto)`
-											: `${shownValue}%`}
-									</div>
-									{!readOnly && (
-										<button
-											onClick={() => onDelete(item.id)}
-											className="delete-button"
+                                                                        disabled={readOnly || (autoFromGoals && goalCount > 0)}
+                                                                />
+                                                                <div className="list-actions">
+                                                                        <div className="list-value">
+                                                                                {autoFromGoals && goalCount > 0
+                                                                                        ? `${derived}% (auto)`
+                                                                                        : `${shownValue}%`}
+                                                                        </div>
+                                                                        {!readOnly && (
+                                                                                <button
+                                                                                        onClick={() => onDelete(item.id)}
+                                                                                        className="delete-button"
 										>
 											Delete
 										</button>
 									)}
 								</div>
 
-								<div className="list-row-controls">
-									<label className="list-label-checkbox">
-										<input
-											type="checkbox"
-											checked={autoFromGoals}
-											onChange={(e) =>
-												onUpdate(item.id, { auto: e.target.checked })
-											}
-											disabled={readOnly}
-										/>
-										Auto from goals
-									</label>
-									<details>
-										<summary className="link-goals-summary">
-											Link goals ({linkedIds.length})
-										</summary>
-										<div className="link-goals-list">
-											{goals.map((g) => {
-												const checked = linkedIds.includes(g.id);
-												return (
-													<label key={g.id} className="link-goals-item">
-														<input
-															type="checkbox"
-															checked={checked}
-															onChange={(e) => {
-																const next = new Set(linkedIds);
-																if (e.target.checked) next.add(g.id);
-																else next.delete(g.id);
-																onUpdate(item.id, {
-																	goalIds: Array.from(next),
-																});
-															}}
-															disabled={readOnly}
-														/>
-														<span>
-															{g.title} ({g.percent ?? 0}%)
-														</span>
-													</label>
-												);
-											})}
-											{onAddGoal && (
-												<AddRow
-													type="goals"
-													placeholder="Add a goal"
-													disabled={readOnly}
-													onAdd={(goal) => onAddGoal(item.id, goal)}
-												/>
-											)}
-										</div>
-									</details>
-								</div>
-							</>
-						)}
+                                                                <div className="list-row-controls">
+                                                                        <label className="list-label-checkbox">
+                                                                                <input
+                                                                                        type="checkbox"
+                                                                                        checked={autoFromGoals}
+                                                                                        onChange={(e) =>
+                                                                                                onUpdate(item.id, { auto: e.target.checked })
+                                                                                        }
+                                                                                        disabled={readOnly}
+                                                                                />
+                                                                                Auto from goals
+                                                                        </label>
+                                                                </div>
+                                                        </>
+                                                )}
 
 						{isGoals && (
 							<>

--- a/src/components/ui/ui.jsx
+++ b/src/components/ui/ui.jsx
@@ -37,8 +37,8 @@ export function AddRow({ type, onAdd, disabled, placeholder }) {
 		const v = text.trim();
 		if (!v) return;
 		if (type === "people") onAdd({ name: v, status: "watching" });
-		if (type === "projects")
-			onAdd({ name: v, percent: 0, goalIds: [], auto: false });
+                if (type === "projects")
+                        onAdd({ name: v, percent: 0, auto: false });
 		if (type === "goals") onAdd({ title: v, percent: 0 });
 		setText("");
 	};

--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import {
         collection,
@@ -11,9 +11,9 @@ import {
 } from "firebase/firestore";
 import { db } from "./firebase";
 import ProjectsOverview from "./components/projects-overview/projects-overview";
-import GoalsOverview from "./components/goals-overview/goals-overview";
 import PeopleOverview from "./components/people-overview/people-overview";
-import { PALETTES } from "./components/ui/ui";
+import List from "./components/list/list";
+import { PALETTES, Card } from "./components/ui/ui";
 
 function useDebouncedCallback(fn, delay = 600) {
         const fnRef = useRef(fn);
@@ -34,14 +34,15 @@ function useDebouncedCallback(fn, delay = 600) {
 export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) {
         const { id: wsId } = useParams();
         const [projects, setProjects] = useState([]);
-        const [goals, setGoals] = useState([]);
         const [people, setPeople] = useState([]);
+        const [projectGoals, setProjectGoals] = useState({});
+        const [selectedProjectId, setSelectedProjectId] = useState("");
 
         useEffect(() => {
                 if (!wsId) {
                         setProjects([]);
-                        setGoals([]);
                         setPeople([]);
+                        setProjectGoals({});
                         return;
                 }
                 const base = doc(db, "workspaces", wsId);
@@ -49,28 +50,43 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         const data = snap.data();
                         if (data?.paletteKey) setPaletteKey(data.paletteKey);
                 });
-                const unsub1 = onSnapshot(collection(base, "projects"), (snap) =>
+                const unsubProjects = onSnapshot(collection(base, "projects"), (snap) =>
                         setProjects(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
                 );
-                const unsub2 = onSnapshot(collection(base, "goals"), (snap) =>
-                        setGoals(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
-                );
-                const unsub3 = onSnapshot(collection(base, "people"), (snap) =>
+                const unsubPeople = onSnapshot(collection(base, "people"), (snap) =>
                         setPeople(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
                 );
                 return () => {
                         unsubWs();
-                        unsub1();
-                        unsub2();
-                        unsub3();
+                        unsubProjects();
+                        unsubPeople();
                 };
         }, [wsId, setPaletteKey]);
+
+        useEffect(() => {
+                if (!wsId) return;
+                const base = doc(db, "workspaces", wsId);
+                const unsubs = projects.map((p) =>
+                        onSnapshot(collection(base, "projects", p.id, "goals"), (snap) => {
+                                setProjectGoals((prev) => ({
+                                        ...prev,
+                                        [p.id]: snap.docs.map((d) => ({ id: d.id, ...d.data() })),
+                                }));
+                        }),
+                );
+                return () => unsubs.forEach((u) => u());
+        }, [wsId, projects]);
 
         const readOnly = !wsId;
 
         const getColRef = (colName) => {
                 if (!wsId) return null;
                 return collection(db, "workspaces", wsId, colName);
+        };
+
+        const getGoalsRef = (projectId) => {
+                if (!wsId || !projectId) return null;
+                return collection(db, "workspaces", wsId, "projects", projectId, "goals");
         };
 
         async function addItem(colName, item) {
@@ -114,10 +130,44 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
         }
 
         async function addGoalToProject(projectId, goal) {
-                const id = await addItem("goals", goal);
-                if (!id) return;
-                const current = projects.find((p) => p.id === projectId)?.goalIds || [];
-                updateItem("projects", projectId, { goalIds: [...current, id] });
+                const ref = getGoalsRef(projectId);
+                if (!ref) {
+                        setBanner("No project selected.");
+                        return "";
+                }
+                try {
+                        const d = await addDoc(ref, { ...goal, createdAt: serverTimestamp() });
+                        return d.id;
+                } catch (err) {
+                        setBanner(`Add goal failed: ${err.message}`);
+                        return "";
+                }
+        }
+
+        async function updateGoal(projectId, id, patch) {
+                const ref = getGoalsRef(projectId);
+                if (!ref) {
+                        setBanner("No project selected.");
+                        return;
+                }
+                try {
+                        await updateDoc(doc(ref, id), patch);
+                } catch (err) {
+                        setBanner(`Update goal failed: ${err.message}`);
+                }
+        }
+
+        async function deleteGoal(projectId, id) {
+                const ref = getGoalsRef(projectId);
+                if (!ref) {
+                        setBanner("No project selected.");
+                        return;
+                }
+                try {
+                        await deleteDoc(doc(ref, id));
+                } catch (err) {
+                        setBanner(`Delete goal failed: ${err.message}`);
+                }
         }
 
         const debouncedPersist = useDebouncedCallback((col, id, patch) => {
@@ -143,33 +193,41 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 setDragging((d) => ({ ...d, [col]: { ...d[col], [id]: val } }));
         }, []);
 
-        const goalsById = useMemo(() => {
-                const m = Object.create(null);
-                for (const g of goals) m[g.id] = g;
-                return m;
-        }, [goals]);
-
-        function computeDerivedPercent(goalIds = []) {
-                const arr = goalIds.map((id) => goalsById[id]?.percent ?? 0);
-                if (!arr.length) return 0;
+        function computeDerivedPercent(projectId) {
+                const arr = projectGoals[projectId]?.map((g) => g.percent ?? 0) || [];
+                if (!arr.length) return { percent: 0, count: 0 };
                 const sum = arr.reduce((a, b) => a + b, 0);
-                return Math.round(sum / arr.length);
+                return { percent: Math.round(sum / arr.length), count: arr.length };
         }
 
         const commitSlider = useCallback(
                 (type, item, liveValue) => {
-                        const col = type;
                         const id = item.id;
                         const pendingValue = pending[type]?.[id];
                         const finalValue = pendingValue ?? liveValue ?? 0;
-                        if (type === "projects")
+                        if (type === "projects") {
                                 debouncedPersist("projects", id, { percent: Number(finalValue) });
-                        if (type === "goals")
-                                debouncedPersist("goals", id, { percent: Number(finalValue) });
+                        }
                         clearPendingValue(type, id);
                         setDraggingFlag(type, id, false);
                 },
                 [pending, debouncedPersist, clearPendingValue, setDraggingFlag],
+        );
+
+        const debouncedGoalPersist = useDebouncedCallback((projectId, id, patch) => {
+                updateGoal(projectId, id, patch);
+        }, 600);
+
+        const commitGoalSlider = useCallback(
+                (projectId, item, liveValue) => {
+                        const id = item.id;
+                        const pendingValue = pending.goals?.[id];
+                        const finalValue = pendingValue ?? liveValue ?? 0;
+                        debouncedGoalPersist(projectId, id, { percent: Number(finalValue) });
+                        clearPendingValue("goals", id);
+                        setDraggingFlag("goals", id, false);
+                },
+                [pending, debouncedGoalPersist, clearPendingValue, setDraggingFlag],
         );
 
         return (
@@ -178,7 +236,6 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                 <ProjectsOverview
                                         paletteKey={paletteKey}
                                         data={projects}
-                                        goals={goals}
                                         onAdd={(item) => addItem("projects", item)}
                                         onUpdate={(id, patch) => updateItem("projects", id, patch)}
                                         onDelete={(id) => deleteItem("projects", id)}
@@ -188,20 +245,36 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         setPendingValue={setPendingValue}
                                         setDraggingFlag={setDraggingFlag}
                                         commitSlider={commitSlider}
-                                        onAddGoal={addGoalToProject}
+                                        selectedId={selectedProjectId}
+                                        onSelectItem={(id) =>
+                                                setSelectedProjectId((prev) =>
+                                                        prev === id ? "" : id,
+                                                )
+                                        }
                                 />
-                                <GoalsOverview
-                                        paletteKey={paletteKey}
-                                        data={goals}
-                                        onAdd={(item) => addItem("goals", item)}
-                                        onUpdate={(id, patch) => updateItem("goals", id, patch)}
-                                        onDelete={(id) => deleteItem("goals", id)}
-                                        readOnly={readOnly}
-                                        pending={pending}
-                                        setPendingValue={setPendingValue}
-                                        setDraggingFlag={setDraggingFlag}
-                                        commitSlider={commitSlider}
-                                />
+
+                                {selectedProjectId ? (
+                                        <List
+                                                title="Goals"
+                                                type="goals"
+                                                data={projectGoals[selectedProjectId] || []}
+                                                onAdd={(item) => addGoalToProject(selectedProjectId, item)}
+                                                onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
+                                                onDelete={(id) => deleteGoal(selectedProjectId, id)}
+                                                readOnly={readOnly}
+                                                pending={pending}
+                                                setPendingValue={setPendingValue}
+                                                setDraggingFlag={setDraggingFlag}
+                                                commitSlider={(type, item, value) =>
+                                                        commitGoalSlider(selectedProjectId, item, value)
+                                                }
+                                        />
+                                ) : (
+                                        <Card title="Goals">
+                                                <div className="list-empty">Select a project to view goals</div>
+                                        </Card>
+                                )}
+
                                 <PeopleOverview
                                         paletteKey={paletteKey}
                                         data={people}


### PR DESCRIPTION
## Summary
- remove global goals module and manage goals under each project
- show goals list when selecting a project
- clean up styles and workspace deletion for nested goals

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve "./firebase-config" from "src/firebase.js")

------
https://chatgpt.com/codex/tasks/task_e_68a8df2a3e58832697c413fd45da63b2