### PR TITLE
Ignore not-found errors on update

### DIFF
--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -113,7 +113,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 try {
                         await updateDoc(doc(ref, id), patch);
                 } catch (err) {
-                        setBanner(`Update failed: ${err.message}`);
+                        if (err.code !== "not-found") {
+                                setBanner(`Update failed: ${err.message}`);
+                        }
                 }
         }
         async function deleteItem(colName, id) {
@@ -153,7 +155,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 try {
                         await updateDoc(doc(ref, id), patch);
                 } catch (err) {
-                        setBanner(`Update goal failed: ${err.message}`);
+                        if (err.code !== "not-found") {
+                                setBanner(`Update goal failed: ${err.message}`);
+                        }
                 }
         }
 


### PR DESCRIPTION
## Summary
- avoid spurious "Update failed" banner when document no longer exists by ignoring Firestore `not-found` errors in update helpers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e202ccc483269f530322c0816aaf