### PR TITLE
Refactor goal tracking to status-based updates

### DIFF
--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -15,13 +15,13 @@
         color: #fff;
 }
 
-.list-row.projects,
-.list-row.goals {
-	grid-template-columns: 1fr minmax(180px, 1fr) auto;
+.list-row.projects {
+        grid-template-columns: 1fr auto;
 }
 
+.list-row.goals,
 .list-row.people {
-	grid-template-columns: 1fr minmax(120px, 160px) auto;
+        grid-template-columns: 1fr minmax(120px, 160px) auto;
 }
 
 .list-value {
@@ -30,31 +30,17 @@
 }
 
 .list-actions {
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-	gap: 8px;
-}
-
-.list-row-controls {
-	grid-column: 1 / -1;
-	display: flex;
-	gap: 12px;
-	align-items: center;
-	opacity: 0.9;
-}
-
-.list-label-checkbox {
-	display: flex;
-	align-items: center;
-	gap: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
 }
 
 .status-select {
-	background: transparent;
-	color: var(--accent);
-	border: 1px solid var(--accent);
-	border-radius: 8px;
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
 	padding: 4px 6px;
 }
 
@@ -63,9 +49,17 @@
 }
 
 .delete-button {
-	color: #ff4d4f;
-	background: transparent;
-	border: 1px solid #ff4d4f;
-	border-radius: 8px;
-	padding: 4px 8px;
+        color: #ff4d4f;
+        background: transparent;
+        border: 1px solid #ff4d4f;
+        border-radius: 8px;
+        padding: 4px 8px;
+}
+
+.list-row.goal-done span {
+        color: #888;
+}
+
+.list-row.goal-doing span {
+        font-weight: bold;
 }

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -12,178 +12,123 @@ export default function List({
         paletteKey,
         readOnly,
         computeDerivedPercent = () => ({ percent: 0, count: 0 }),
-        pending,
-        setPendingValue,
-        setDraggingFlag,
-        commitSlider,
         onSelectItem,
         selectedId,
 }) {
-	return (
-		<Card
-			title={title}
-			right={readOnly ? <span className="muted">Read only</span> : null}
-		>
-			{!data.length && <div className="list-empty">No items</div>}
+        return (
+                <Card
+                        title={title}
+                        right={readOnly ? <span className="muted">Read only</span> : null}
+                >
+                        {!data.length && <div className="list-empty">No items</div>}
 
-			{data.map((item) => {
-				const isProjects = type === "projects";
-				const isGoals = type === "goals";
-				const isPeople = type === "people";
+                        {data.map((item) => {
+                                const isProjects = type === "projects";
+                                const isGoals = type === "goals";
+                                const isPeople = type === "people";
 
-                                const colKey = isProjects ? "projects" : isGoals ? "goals" : null;
-                                const autoFromGoals = isProjects ? (item.auto ?? false) : false;
-                                const { percent: derived, count: goalCount } = isProjects
+                                const { percent: derived } = isProjects
                                         ? computeDerivedPercent(item.id)
-                                        : { percent: 0, count: 0 };
-                                const baseLive = isProjects
-                                        ? (item.percent ?? 0)
-                                        : isGoals
-                                                ? (item.percent ?? 0)
-                                                : 0;
-                                const liveValue =
-                                        isProjects && autoFromGoals && goalCount ? derived : baseLive;
-                                const pendingValue = colKey ? pending[colKey][item.id] : undefined;
-                                const shownValue =
-                                        pendingValue !== undefined ? pendingValue : liveValue;
+                                        : { percent: 0 };
 
                                 return (
                                         <div
                                                 key={item.id}
                                                 className={`list-row ${type} ${
-                                                        selectedId === item.id ? "selected" : ""
-                                                }`}
+                                                        isGoals && item.status ? `goal-${item.status}` : ""
+                                                } ${selectedId === item.id ? "selected" : ""}`}
                                                 onClick={() => onSelectItem && onSelectItem(item.id)}
                                         >
                                                 {isProjects && (
                                                         <>
                                                                 <span>{item.name}</span>
-                                                                <input
-									type="range"
-									min={0}
-									max={100}
-									step={1}
-									value={shownValue}
-									onChange={(e) =>
-										setPendingValue("projects", item.id, Number(e.target.value))
-									}
-									onMouseDown={() => setDraggingFlag("projects", item.id, true)}
-									onTouchStart={() =>
-										setDraggingFlag("projects", item.id, true)
-									}
-									onMouseUp={() => commitSlider("projects", item, liveValue)}
-									onTouchEnd={() => commitSlider("projects", item, liveValue)}
-									onBlur={() => commitSlider("projects", item, liveValue)}
-                                                                        disabled={readOnly || (autoFromGoals && goalCount > 0)}
-                                                                />
                                                                 <div className="list-actions">
-                                                                        <div className="list-value">
-                                                                                {autoFromGoals && goalCount > 0
-                                                                                        ? `${derived}% (auto)`
-                                                                                        : `${shownValue}%`}
-                                                                        </div>
+                                                                        <div className="list-value">{derived}%</div>
                                                                         {!readOnly && (
                                                                                 <button
                                                                                         onClick={() => onDelete(item.id)}
                                                                                         className="delete-button"
-										>
-											Delete
-										</button>
-									)}
-								</div>
-
-                                                                <div className="list-row-controls">
-                                                                        <label className="list-label-checkbox">
-                                                                                <input
-                                                                                        type="checkbox"
-                                                                                        checked={autoFromGoals}
-                                                                                        onChange={(e) =>
-                                                                                                onUpdate(item.id, { auto: e.target.checked })
-                                                                                        }
-                                                                                        disabled={readOnly}
-                                                                                />
-                                                                                Auto from goals
-                                                                        </label>
+                                                                                >
+                                                                                        Delete
+                                                                                </button>
+                                                                        )}
                                                                 </div>
                                                         </>
                                                 )}
 
-						{isGoals && (
-							<>
-								<span>{item.title}</span>
-								<input
-									type="range"
-									min={0}
-									max={100}
-									step={1}
-									value={shownValue}
-									onChange={(e) =>
-										setPendingValue("goals", item.id, Number(e.target.value))
-									}
-									onMouseDown={() => setDraggingFlag("goals", item.id, true)}
-									onTouchStart={() => setDraggingFlag("goals", item.id, true)}
-									onMouseUp={() => commitSlider("goals", item, liveValue)}
-									onTouchEnd={() => commitSlider("goals", item, liveValue)}
-									onBlur={() => commitSlider("goals", item, liveValue)}
-									disabled={readOnly}
-								/>
-								<div className="list-actions">
-									<div className="list-value">{shownValue}%</div>
-									{!readOnly && (
-										<button
-											onClick={() => onDelete(item.id)}
-											className="delete-button"
-										>
-											Delete
-										</button>
-									)}
-								</div>
-							</>
-						)}
+                                                {isGoals && (
+                                                        <>
+                                                                <span>{item.title}</span>
+                                                                <select
+                                                                        className="status-select"
+                                                                        value={item.status || "todo"}
+                                                                        onChange={(e) =>
+                                                                                onUpdate(item.id, {
+                                                                                        status: e.target.value,
+                                                                                })
+                                                                        }
+                                                                        disabled={readOnly}
+                                                                >
+                                                                        <option value="todo">To do</option>
+                                                                        <option value="doing">Doing</option>
+                                                                        <option value="done">Done</option>
+                                                                </select>
+                                                                {!readOnly && (
+                                                                        <button
+                                                                                onClick={() => onDelete(item.id)}
+                                                                                className="delete-button"
+                                                                        >
+                                                                                Delete
+                                                                        </button>
+                                                                )}
+                                                        </>
+                                                )}
 
-						{isPeople && (
-							<>
-								<span>{item.name}</span>
-								<select
-									className="status-select"
-									value={item.status || "watching"}
-									onChange={(e) =>
-										onUpdate(item.id, { status: e.target.value })
-									}
-									disabled={readOnly}
-								>
-									<option value="watching">watching</option>
-									<option value="ongoing">ongoing</option>
-									<option value="completed">completed</option>
-								</select>
-								{!readOnly && (
-									<button
-										onClick={() => onDelete(item.id)}
-										className="delete-button"
-									>
-										Delete
-									</button>
-								)}
-							</>
-						)}
-					</div>
-				);
-			})}
+                                                {isPeople && (
+                                                        <>
+                                                                <span>{item.name}</span>
+                                                                <select
+                                                                        className="status-select"
+                                                                        value={item.status || "watching"}
+                                                                        onChange={(e) =>
+                                                                                onUpdate(item.id, {
+                                                                                        status: e.target.value,
+                                                                                })
+                                                                        }
+                                                                        disabled={readOnly}
+                                                                >
+                                                                        <option value="watching">watching</option>
+                                                                        <option value="ongoing">ongoing</option>
+                                                                        <option value="completed">completed</option>
+                                                                </select>
+                                                                {!readOnly && (
+                                                                        <button
+                                                                                onClick={() => onDelete(item.id)}
+                                                                                className="delete-button"
+                                                                        >
+                                                                                Delete
+                                                                        </button>
+                                                                )}
+                                                        </>
+                                                )}
+                                        </div>
+                                );
+                        })}
 
-			{!readOnly && (
-				<AddRow
-					type={type}
-					placeholder={
-						type === "people"
-							? "Add a person/project"
-							: type === "goals"
-								? "Add a goal"
-								: "Add a project"
-					}
-					disabled={readOnly}
-					onAdd={onAdd}
-				/>
-			)}
-		</Card>
-	);
+                        {!readOnly && (
+                                <AddRow
+                                        type={type}
+                                        placeholder={
+                                                type === "people"
+                                                        ? "Add a person/project"
+                                                        : type === "goals"
+                                                                ? "Add a goal"
+                                                                : "Add a project"
+                                        }
+                                        disabled={readOnly}
+                                        onAdd={onAdd}
+                                />
+                        )}
+                </Card>
+        );
 }

--- a/src/components/ui/ui.jsx
+++ b/src/components/ui/ui.jsx
@@ -36,10 +36,9 @@ export function AddRow({ type, onAdd, disabled, placeholder }) {
 	const handleSubmit = () => {
 		const v = text.trim();
 		if (!v) return;
-		if (type === "people") onAdd({ name: v, status: "watching" });
-                if (type === "projects")
-                        onAdd({ name: v, percent: 0, auto: false });
-		if (type === "goals") onAdd({ title: v, percent: 0 });
+                if (type === "people") onAdd({ name: v, status: "watching" });
+                if (type === "projects") onAdd({ name: v, percent: 0 });
+                if (type === "goals") onAdd({ title: v, status: "todo" });
 		setText("");
 	};
 	return (

--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
         collection,
@@ -14,22 +14,6 @@ import ProjectsOverview from "./components/projects-overview/projects-overview";
 import PeopleOverview from "./components/people-overview/people-overview";
 import List from "./components/list/list";
 import { PALETTES, Card } from "./components/ui/ui";
-
-function useDebouncedCallback(fn, delay = 600) {
-        const fnRef = useRef(fn);
-        const timer = useRef(null);
-        useEffect(() => {
-                fnRef.current = fn;
-        }, [fn]);
-        useEffect(() => () => timer.current && clearTimeout(timer.current), []);
-        return useCallback(
-                (...args) => {
-                        if (timer.current) clearTimeout(timer.current);
-                        timer.current = setTimeout(() => fnRef.current(...args), delay);
-                },
-                [delay],
-        );
-}
 
 export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) {
         const { id: wsId } = useParams();
@@ -174,65 +158,26 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 }
         }
 
-        const debouncedPersist = useDebouncedCallback((col, id, patch) => {
-                updateItem(col, id, patch);
-        }, 600);
-
-        const [pending, setPending] = useState({ projects: {}, goals: {} });
-        const [dragging, setDragging] = useState({ projects: {}, goals: {} });
-
-        const setPendingValue = useCallback((col, id, value) => {
-                setPending((p) => ({ ...p, [col]: { ...p[col], [id]: value } }));
-        }, []);
-
-        const clearPendingValue = useCallback((col, id) => {
-                setPending((p) => {
-                        const copy = { ...p[col] };
-                        delete copy[id];
-                        return { ...p, [col]: copy };
-                });
-        }, []);
-
-        const setDraggingFlag = useCallback((col, id, val) => {
-                setDragging((d) => ({ ...d, [col]: { ...d[col], [id]: val } }));
-        }, []);
-
         function computeDerivedPercent(projectId) {
-                const arr = projectGoals[projectId]?.map((g) => g.percent ?? 0) || [];
+                const arr =
+                        projectGoals[projectId]?.map((g) => {
+                                if (g.status === "done") return 100;
+                                if (g.status === "doing") return 50;
+                                return 0;
+                        }) || [];
                 if (!arr.length) return { percent: 0, count: 0 };
                 const sum = arr.reduce((a, b) => a + b, 0);
                 return { percent: Math.round(sum / arr.length), count: arr.length };
         }
 
-        const commitSlider = useCallback(
-                (type, item, liveValue) => {
-                        const id = item.id;
-                        const pendingValue = pending[type]?.[id];
-                        const finalValue = pendingValue ?? liveValue ?? 0;
-                        if (type === "projects") {
-                                debouncedPersist("projects", id, { percent: Number(finalValue) });
+        useEffect(() => {
+                projects.forEach((p) => {
+                        const { percent } = computeDerivedPercent(p.id);
+                        if (p.percent !== percent) {
+                                updateItem("projects", p.id, { percent });
                         }
-                        clearPendingValue(type, id);
-                        setDraggingFlag(type, id, false);
-                },
-                [pending, debouncedPersist, clearPendingValue, setDraggingFlag],
-        );
-
-        const debouncedGoalPersist = useDebouncedCallback((projectId, id, patch) => {
-                updateGoal(projectId, id, patch);
-        }, 600);
-
-        const commitGoalSlider = useCallback(
-                (projectId, item, liveValue) => {
-                        const id = item.id;
-                        const pendingValue = pending.goals?.[id];
-                        const finalValue = pendingValue ?? liveValue ?? 0;
-                        debouncedGoalPersist(projectId, id, { percent: Number(finalValue) });
-                        clearPendingValue("goals", id);
-                        setDraggingFlag("goals", id, false);
-                },
-                [pending, debouncedGoalPersist, clearPendingValue, setDraggingFlag],
-        );
+                });
+        }, [projects, projectGoals]);
 
         return (
                 <>
@@ -245,10 +190,6 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         onDelete={(id) => deleteItem("projects", id)}
                                         readOnly={readOnly}
                                         computeDerivedPercent={computeDerivedPercent}
-                                        pending={pending}
-                                        setPendingValue={setPendingValue}
-                                        setDraggingFlag={setDraggingFlag}
-                                        commitSlider={commitSlider}
                                         selectedId={selectedProjectId}
                                         onSelectItem={(id) =>
                                                 setSelectedProjectId((prev) =>
@@ -266,12 +207,6 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                                 onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
                                                 onDelete={(id) => deleteGoal(selectedProjectId, id)}
                                                 readOnly={readOnly}
-                                                pending={pending}
-                                                setPendingValue={setPendingValue}
-                                                setDraggingFlag={setDraggingFlag}
-                                                commitSlider={(type, item, value) =>
-                                                        commitGoalSlider(selectedProjectId, item, value)
-                                                }
                                         />
                                 ) : (
                                         <Card title="Goals">
@@ -286,10 +221,6 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         onUpdate={(id, patch) => updateItem("people", id, patch)}
                                         onDelete={(id) => deleteItem("people", id)}
                                         readOnly={readOnly}
-                                        pending={pending}
-                                        setPendingValue={setPendingValue}
-                                        setDraggingFlag={setDraggingFlag}
-                                        commitSlider={commitSlider}
                                 />
                         </div>
 


### PR DESCRIPTION
## Summary
- Replace goal percent sliders with status dropdowns (To do, Doing, Done) and style accordingly
- Display project progress based on goal statuses and remove manual/auto controls
- Auto-sync project completion percentage from goal statuses

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Could not resolve "./firebase-config" from "src/firebase.js")

------
https://chatgpt.com/codex/tasks/task_e_68a8e4d69ff48326bc9eae2eb8b59c28