### PR TITLE
Add profile pages and mobile workspace creation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,8 @@ import { Link, Routes, Route, useLocation, useNavigate } from "react-router-dom"
 import { db, auth, provider } from "./firebase";
 import Header from "./components/header/header";
 import WorkspacePage from "./workspace-page";
+import CreateProfile from "./create-profile";
+import EditProfile from "./edit-profile";
 import { Card, Button } from "./components/ui/ui";
 import "./App.css";
 
@@ -231,6 +233,7 @@ export default function App() {
                                         provider={provider}
                                         workspaces={workspaces}
                                         currentWsId={currentWsId}
+                                        createWorkspace={createWorkspace}
                                 />
 
                                 {banner && <div className="banner">{banner}</div>}
@@ -255,6 +258,8 @@ export default function App() {
                                                         />
                                                 }
                                         />
+                                        <Route path="/profile/new" element={<CreateProfile />} />
+                                        <Route path="/profile/edit" element={<EditProfile />} />
                                         <Route path="*" element={<div>Select a workspace</div>} />
                                 </Routes>
                         </div>

--- a/src/components/header/auth-panel.jsx
+++ b/src/components/header/auth-panel.jsx
@@ -4,6 +4,7 @@ import {
         signInWithEmailAndPassword,
         signOut,
 } from "firebase/auth";
+import { Link } from "react-router-dom";
 import { Button } from "../ui/ui";
 
 export default function AuthPanel({ user, auth, provider }) {
@@ -46,6 +47,9 @@ export default function AuthPanel({ user, auth, provider }) {
                         {user ? (
                                 <>
                                         <span className="greeting">Hi, {user.displayName || user.email}</span>
+                                        <Link to="/profile/edit" className="auth-link">
+                                                Edit profile
+                                        </Link>
                                         <Button onClick={handleSignOut} subtle>
                                                 Sign out
                                         </Button>
@@ -68,6 +72,9 @@ export default function AuthPanel({ user, auth, provider }) {
                                         />
                                         <Button onClick={handleEmailSignIn}>Login</Button>
                                         <Button onClick={handleGoogleSignIn}>Google</Button>
+                                        <Link to="/profile/new" className="auth-link">
+                                                Create profile
+                                        </Link>
                                 </>
                         )}
                         {error && <span className="auth-error">{error}</span>}

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -111,6 +111,16 @@
         gap: 8px;
 }
 
+.mobile-workspace-create {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+}
+
+.auth-link {
+        color: var(--accent);
+}
+
 @media (max-width: 600px) {
         .header-controls {
                 display: none;

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -12,6 +12,7 @@ export default function Header({
         provider,
         workspaces,
         currentWsId,
+        createWorkspace,
 }) {
 	return (
 		<div className="header">
@@ -39,6 +40,7 @@ export default function Header({
                                 provider={provider}
                                 workspaces={workspaces}
                                 currentWsId={currentWsId}
+                                createWorkspace={createWorkspace}
                         />
                 </div>
         );

--- a/src/components/header/mobile-menu.jsx
+++ b/src/components/header/mobile-menu.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import { PALETTES } from "../ui/ui";
+import { PALETTES, Button } from "../ui/ui";
 import AuthPanel from "./auth-panel";
 
 export default function MobileMenu({
@@ -11,8 +11,10 @@ export default function MobileMenu({
         provider,
         workspaces,
         currentWsId,
+        createWorkspace,
 }) {
         const [open, setOpen] = useState(false);
+        const [name, setName] = useState("");
         return (
                 <div className="mobile-menu-container">
                         <button
@@ -54,6 +56,25 @@ export default function MobileMenu({
                                                                 {w.name || "Untitled"}
                                                         </Link>
                                                 ))}
+                                        </div>
+                                        <div className="mobile-workspace-create">
+                                                <input
+                                                        className="workspace-bar-input"
+                                                        value={name}
+                                                        onChange={(e) => setName(e.target.value)}
+                                                        placeholder="New workspace name"
+                                                />
+                                                <Button
+                                                        onClick={async () => {
+                                                                const n = name.trim();
+                                                                if (!n) return;
+                                                                await createWorkspace(n);
+                                                                setName("");
+                                                                setOpen(false);
+                                                        }}
+                                                >
+                                                        Create
+                                                </Button>
                                         </div>
                                         <AuthPanel
                                                 user={user}

--- a/src/components/ui/ui.jsx
+++ b/src/components/ui/ui.jsx
@@ -43,15 +43,18 @@ export function AddRow({ type, onAdd, disabled, placeholder }) {
 	};
 	return (
 		<div className="add-row">
-			<input
-				disabled={disabled}
-				value={text}
-				onChange={(e) => setText(e.target.value)}
-				placeholder={placeholder}
-			/>
-			<button onClick={handleSubmit} disabled={disabled}>
-				Add
-			</button>
-		</div>
+                        <input
+                                disabled={disabled}
+                                value={text}
+                                onChange={(e) => setText(e.target.value)}
+                                onKeyDown={(e) => {
+                                        if (e.key === "Enter") handleSubmit();
+                                }}
+                                placeholder={placeholder}
+                        />
+                        <button onClick={handleSubmit} disabled={disabled}>
+                                Add
+                        </button>
+                </div>
 	);
 }

--- a/src/create-profile.jsx
+++ b/src/create-profile.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
+import { auth } from "./firebase";
+import { Card, Button } from "./components/ui/ui";
+import { useNavigate, Link } from "react-router-dom";
+
+export default function CreateProfile() {
+        const [displayName, setDisplayName] = useState("");
+        const [email, setEmail] = useState("");
+        const [password, setPassword] = useState("");
+        const [error, setError] = useState("");
+        const navigate = useNavigate();
+
+        const handleCreate = async () => {
+                try {
+                        setError("");
+                        const cred = await createUserWithEmailAndPassword(auth, email, password);
+                        if (displayName) {
+                                await updateProfile(cred.user, { displayName });
+                        }
+                        navigate("/");
+                } catch (e) {
+                        console.error("create profile failed", e);
+                        setError("Create profile failed");
+                }
+        };
+
+        return (
+                <div className="profile-page">
+                        <Card title="Create Profile" right={null}>
+                                <input
+                                        className="auth-input"
+                                        type="text"
+                                        placeholder="Display Name"
+                                        value={displayName}
+                                        onChange={(e) => setDisplayName(e.target.value)}
+                                />
+                                <input
+                                        className="auth-input"
+                                        type="email"
+                                        placeholder="Email"
+                                        value={email}
+                                        onChange={(e) => setEmail(e.target.value)}
+                                />
+                                <input
+                                        className="auth-input"
+                                        type="password"
+                                        placeholder="Password"
+                                        value={password}
+                                        onChange={(e) => setPassword(e.target.value)}
+                                />
+                                <Button onClick={handleCreate}>Create Account</Button>
+                                {error && <div className="auth-error">{error}</div>}
+                                <Link to="/" className="auth-link">
+                                        Back
+                                </Link>
+                        </Card>
+                </div>
+        );
+}

--- a/src/edit-profile.jsx
+++ b/src/edit-profile.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { updateProfile } from "firebase/auth";
+import { auth } from "./firebase";
+import { Card, Button } from "./components/ui/ui";
+import { useNavigate } from "react-router-dom";
+
+export default function EditProfile() {
+        const user = auth.currentUser;
+        const [displayName, setDisplayName] = useState(user?.displayName || "");
+        const [message, setMessage] = useState("");
+        const [error, setError] = useState("");
+        const navigate = useNavigate();
+
+        const handleSave = async () => {
+                if (!user) return;
+                try {
+                        setError("");
+                        await updateProfile(user, { displayName });
+                        setMessage("Profile updated");
+                } catch (e) {
+                        console.error("profile update failed", e);
+                        setError("Update failed");
+                }
+        };
+
+        if (!user) {
+                return <div className="profile-page">Please sign in to edit your profile.</div>;
+        }
+
+        return (
+                <div className="profile-page">
+                        <Card title="Edit Profile" right={null}>
+                                <input
+                                        className="auth-input"
+                                        type="text"
+                                        placeholder="Display Name"
+                                        value={displayName}
+                                        onChange={(e) => setDisplayName(e.target.value)}
+                                />
+                                <Button onClick={handleSave}>Save</Button>
+                                {message && <span className="greeting">{message}</span>}
+                                {error && <div className="auth-error">{error}</div>}
+                                <Button onClick={() => navigate(-1)} subtle>
+                                        Back
+                                </Button>
+                        </Card>
+                </div>
+        );
+}

--- a/src/edit-profile.jsx
+++ b/src/edit-profile.jsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
-import { updateProfile } from "firebase/auth";
+import {
+        updateProfile,
+        updateEmail,
+        updatePassword,
+} from "firebase/auth";
 import { auth } from "./firebase";
 import { Card, Button } from "./components/ui/ui";
 import { useNavigate } from "react-router-dom";
@@ -7,16 +11,33 @@ import { useNavigate } from "react-router-dom";
 export default function EditProfile() {
         const user = auth.currentUser;
         const [displayName, setDisplayName] = useState(user?.displayName || "");
+        const [email, setEmail] = useState(user?.email || "");
+        const [password, setPassword] = useState("");
         const [message, setMessage] = useState("");
         const [error, setError] = useState("");
         const navigate = useNavigate();
+
+        const isPasswordUser = user?.providerData.some(
+                (p) => p.providerId === "password",
+        );
 
         const handleSave = async () => {
                 if (!user) return;
                 try {
                         setError("");
-                        await updateProfile(user, { displayName });
+                        if (displayName !== user.displayName) {
+                                await updateProfile(user, { displayName });
+                        }
+                        if (isPasswordUser) {
+                                if (email && email !== user.email) {
+                                        await updateEmail(user, email);
+                                }
+                                if (password) {
+                                        await updatePassword(user, password);
+                                }
+                        }
                         setMessage("Profile updated");
+                        setPassword("");
                 } catch (e) {
                         console.error("profile update failed", e);
                         setError("Update failed");
@@ -37,6 +58,28 @@ export default function EditProfile() {
                                         value={displayName}
                                         onChange={(e) => setDisplayName(e.target.value)}
                                 />
+                                <input
+                                        className="auth-input"
+                                        type="email"
+                                        placeholder="Email"
+                                        value={email}
+                                        onChange={(e) => setEmail(e.target.value)}
+                                        disabled={!isPasswordUser}
+                                />
+                                {isPasswordUser && (
+                                        <input
+                                                className="auth-input"
+                                                type="password"
+                                                placeholder="New Password"
+                                                value={password}
+                                                onChange={(e) => setPassword(e.target.value)}
+                                        />
+                                )}
+                                {!isPasswordUser && (
+                                        <div className="auth-error">
+                                                Email and password managed by external provider
+                                        </div>
+                                )}
                                 <Button onClick={handleSave}>Save</Button>
                                 {message && <span className="greeting">{message}</span>}
                                 {error && <div className="auth-error">{error}</div>}


### PR DESCRIPTION
## Summary
- add CreateProfile and EditProfile pages to register accounts and change display names
- expose profile links in AuthPanel and wire up new routes
- allow workspace creation from mobile menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8f07f03788326a95d7ac06eb6fa4b