### PR TITLE
Add login page and redirect unauthenticated users

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -122,3 +122,14 @@
         --accent: #00b4d8;
         --accent-subtle: #90e0ef;
 }
+
+.profile-page {
+        display: flex;
+        justify-content: center;
+        margin-top: 40px;
+}
+
+.auth-grid {
+        display: grid;
+        gap: 12px;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,7 +100,11 @@ const currentWsId = location.pathname.startsWith("/workspace/")
         : "";
 
        useEffect(() => {
-               if (!user && location.pathname !== "/login") {
+               if (
+                       !user &&
+                       location.pathname !== "/login" &&
+                       location.pathname !== "/profile/new"
+               ) {
                        navigate("/login");
                }
        }, [user, location.pathname, navigate]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,11 +13,12 @@ import {
         getDocs,
 } from "firebase/firestore";
 import { Link, Routes, Route, useLocation, useNavigate } from "react-router-dom";
-import { db, auth, provider } from "./firebase";
+import { db, auth } from "./firebase";
 import Header from "./components/header/header";
 import WorkspacePage from "./workspace-page";
 import CreateProfile from "./create-profile";
 import EditProfile from "./edit-profile";
+import LoginPage from "./login-page";
 import { Card, Button } from "./components/ui/ui";
 import "./App.css";
 
@@ -92,15 +93,21 @@ export default function App() {
         const [banner, setBanner] = useState("");
         const [workspaces, setWorkspaces] = useState([]);
 
-        const location = useLocation();
-        const navigate = useNavigate();
-        const currentWsId = location.pathname.startsWith("/workspace/")
-                ? location.pathname.split("/")[2]
-                : "";
+const location = useLocation();
+const navigate = useNavigate();
+const currentWsId = location.pathname.startsWith("/workspace/")
+        ? location.pathname.split("/")[2]
+        : "";
 
-        useEffect(() => {
-                if (!user) {
-                        setWorkspaces([]);
+       useEffect(() => {
+               if (!user && location.pathname !== "/login") {
+                       navigate("/login");
+               }
+       }, [user, location.pathname, navigate]);
+
+       useEffect(() => {
+               if (!user) {
+                       setWorkspaces([]);
                         return;
                 }
                 const q = query(
@@ -225,43 +232,49 @@ export default function App() {
         return (
                 <div className={`app palette-${paletteKey}`}>
                         <div className="container">
-                                <Header
-                                        paletteKey={paletteKey}
-                                        setPaletteKey={handlePaletteChange}
-                                        user={user}
-                                        auth={auth}
-                                        provider={provider}
-                                        workspaces={workspaces}
-                                        currentWsId={currentWsId}
-                                        createWorkspace={createWorkspace}
-                                />
+                               <Header
+                                       paletteKey={paletteKey}
+                                       setPaletteKey={handlePaletteChange}
+                                       user={user}
+                                       auth={auth}
+                                       workspaces={workspaces}
+                                       currentWsId={currentWsId}
+                                       createWorkspace={createWorkspace}
+                               />
 
                                 {banner && <div className="banner">{banner}</div>}
 
-                                <WorkspaceNav
-                                        workspaces={workspaces}
-                                        currentWsId={currentWsId}
-                                        createWorkspace={createWorkspace}
-                                        deleteWorkspace={deleteWorkspace}
-                                        resetLocal={resetLocal}
-                                        testConnection={testConnection}
-                                />
+                               {user && (
+                                       <WorkspaceNav
+                                               workspaces={workspaces}
+                                               currentWsId={currentWsId}
+                                               createWorkspace={createWorkspace}
+                                               deleteWorkspace={deleteWorkspace}
+                                               resetLocal={resetLocal}
+                                               testConnection={testConnection}
+                                       />
+                               )}
 
-                                <Routes>
-                                        <Route
-                                                path="/workspace/:id"
-                                                element={
-                                                        <WorkspacePage
-                                                                paletteKey={paletteKey}
-                                                                setPaletteKey={setPaletteKey}
-                                                                setBanner={setBanner}
-                                                        />
-                                                }
-                                        />
-                                        <Route path="/profile/new" element={<CreateProfile />} />
-                                        <Route path="/profile/edit" element={<EditProfile />} />
-                                        <Route path="*" element={<div>Select a workspace</div>} />
-                                </Routes>
+                               <Routes>
+                                       <Route path="/login" element={<LoginPage />} />
+                                       {user && (
+                                               <>
+                                                       <Route
+                                                               path="/workspace/:id"
+                                                               element={
+                                                                       <WorkspacePage
+                                                                               paletteKey={paletteKey}
+                                                                               setPaletteKey={setPaletteKey}
+                                                                               setBanner={setBanner}
+                                                                       />
+                                                               }
+                                                       />
+                                                       <Route path="/profile/new" element={<CreateProfile />} />
+                                                       <Route path="/profile/edit" element={<EditProfile />} />
+                                                       <Route path="*" element={<div>Select a workspace</div>} />
+                                               </>
+                                       )}
+                               </Routes>
                         </div>
                 </div>
         );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -261,6 +261,7 @@ const currentWsId = location.pathname.startsWith("/workspace/")
 
                                <Routes>
                                        <Route path="/login" element={<LoginPage />} />
+                                       <Route path="/profile/new" element={<CreateProfile />} />
                                        {user && (
                                                <>
                                                        <Route
@@ -273,7 +274,6 @@ const currentWsId = location.pathname.startsWith("/workspace/")
                                                                        />
                                                                }
                                                        />
-                                                       <Route path="/profile/new" element={<CreateProfile />} />
                                                        <Route path="/profile/edit" element={<EditProfile />} />
                                                        <Route path="*" element={<div>Select a workspace</div>} />
                                                </>

--- a/src/components/header/auth-panel.jsx
+++ b/src/components/header/auth-panel.jsx
@@ -1,83 +1,39 @@
 import React, { useState } from "react";
-import {
-        signInWithPopup,
-        signInWithEmailAndPassword,
-        signOut,
-} from "firebase/auth";
+import { signOut } from "firebase/auth";
 import { Link } from "react-router-dom";
 import { Button } from "../ui/ui";
 
-export default function AuthPanel({ user, auth, provider }) {
-        const [error, setError] = useState("");
-        const [email, setEmail] = useState("");
-        const [password, setPassword] = useState("");
+export default function AuthPanel({ user, auth }) {
+const [error, setError] = useState("");
 
-        const handleGoogleSignIn = async () => {
-                try {
-                        setError("");
-                        await signInWithPopup(auth, provider);
-                } catch (e) {
-                        console.error("sign-in failed", e);
-                        setError("Sign in failed");
-                }
-        };
+const handleSignOut = async () => {
+try {
+setError("");
+await signOut(auth);
+} catch (e) {
+console.error("sign-out failed", e);
+setError("Sign out failed");
+}
+};
 
-        const handleEmailSignIn = async () => {
-                try {
-                        setError("");
-                        await signInWithEmailAndPassword(auth, email, password);
-                } catch (e) {
-                        console.error("email sign-in failed", e);
-                        setError("Sign in failed");
-                }
-        };
-
-        const handleSignOut = async () => {
-                try {
-                        setError("");
-                        await signOut(auth);
-                } catch (e) {
-                        console.error("sign-out failed", e);
-                        setError("Sign out failed");
-                }
-        };
-
-        return (
-                <div className="auth-panel">
-                        {user ? (
-                                <>
-                                        <span className="greeting">Hi, {user.displayName || user.email}</span>
-                                        <Link to="/profile/edit" className="auth-link">
-                                                Edit profile
-                                        </Link>
-                                        <Button onClick={handleSignOut} subtle>
-                                                Sign out
-                                        </Button>
-                                </>
-                        ) : (
-                                <>
-                                        <input
-                                                className="auth-input"
-                                                type="email"
-                                                placeholder="Email"
-                                                value={email}
-                                                onChange={(e) => setEmail(e.target.value)}
-                                        />
-                                        <input
-                                                className="auth-input"
-                                                type="password"
-                                                placeholder="Password"
-                                                value={password}
-                                                onChange={(e) => setPassword(e.target.value)}
-                                        />
-                                        <Button onClick={handleEmailSignIn}>Login</Button>
-                                        <Button onClick={handleGoogleSignIn}>Google</Button>
-                                        <Link to="/profile/new" className="auth-link">
-                                                Create profile
-                                        </Link>
-                                </>
-                        )}
-                        {error && <span className="auth-error">{error}</span>}
-                </div>
-        );
+return (
+<div className="auth-panel">
+{user ? (
+<>
+<span className="greeting">Hi, {user.displayName || user.email}</span>
+<Link to="/profile/edit" className="auth-link">
+Edit profile
+</Link>
+<Button onClick={handleSignOut} subtle>
+Sign out
+</Button>
+</>
+) : (
+<Link to="/login" className="auth-link">
+Login
+</Link>
+)}
+{error && <span className="auth-error">{error}</span>}
+</div>
+);
 }

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -5,43 +5,41 @@ import MobileMenu from "./mobile-menu";
 import "./header.css";
 
 export default function Header({
-        paletteKey,
-        setPaletteKey,
-        user,
-        auth,
-        provider,
-        workspaces,
-        currentWsId,
-        createWorkspace,
+	paletteKey,
+	setPaletteKey,
+	user,
+	auth,
+	workspaces,
+	currentWsId,
+	createWorkspace,
 }) {
 	return (
 		<div className="header">
 			<h2 className="header-title">Project Tracker</h2>
-                        <div className="header-controls">
-                                <AuthPanel user={user} auth={auth} provider={provider} />
-                                <label className="theme-label">Theme</label>
-                                <select
-                                        className="theme-select"
-                                        value={paletteKey}
-                                        onChange={(e) => setPaletteKey(e.target.value)}
-                                >
-                                        {Object.entries(PALETTES).map(([k, v]) => (
-                                                <option key={k} value={k}>
-                                                        {v.name}
-                                                </option>
-                                        ))}
-                                </select>
-                        </div>
-                        <MobileMenu
-                                paletteKey={paletteKey}
-                                setPaletteKey={setPaletteKey}
-                                user={user}
-                                auth={auth}
-                                provider={provider}
-                                workspaces={workspaces}
-                                currentWsId={currentWsId}
-                                createWorkspace={createWorkspace}
-                        />
-                </div>
-        );
+			<div className="header-controls">
+				<AuthPanel user={user} auth={auth} />
+				<label className="theme-label">Theme</label>
+				<select
+					className="theme-select"
+					value={paletteKey}
+					onChange={(e) => setPaletteKey(e.target.value)}
+				>
+					{Object.entries(PALETTES).map(([k, v]) => (
+						<option key={k} value={k}>
+							{v.name}
+						</option>
+					))}
+				</select>
+			</div>
+			<MobileMenu
+				paletteKey={paletteKey}
+				setPaletteKey={setPaletteKey}
+				user={user}
+				auth={auth}
+				workspaces={workspaces}
+				currentWsId={currentWsId}
+				createWorkspace={createWorkspace}
+			/>
+		</div>
+	);
 }

--- a/src/components/header/mobile-menu.jsx
+++ b/src/components/header/mobile-menu.jsx
@@ -4,97 +4,95 @@ import { PALETTES, Button } from "../ui/ui";
 import AuthPanel from "./auth-panel";
 
 export default function MobileMenu({
-        paletteKey,
-        setPaletteKey,
-        user,
-        auth,
-        provider,
-        workspaces,
-        currentWsId,
-        createWorkspace,
+	paletteKey,
+	setPaletteKey,
+	user,
+	auth,
+	workspaces,
+	currentWsId,
+	createWorkspace,
 }) {
-        const [open, setOpen] = useState(false);
-        const [name, setName] = useState("");
-        return (
-                <div className="mobile-menu-container">
-                        <button
-                                className="mobile-menu-button"
-                                onClick={() => setOpen(true)}
-                        >
-                                ☰
-                        </button>
-                        <div
-                                className={`mobile-menu-overlay ${open ? "open" : ""}`}
-                                onClick={() => setOpen(false)}
-                        >
-                                <div
-                                        className="mobile-menu-drawer"
-                                        onClick={(e) => e.stopPropagation()}
-                                >
-                                        <button
-                                                className="mobile-menu-close"
-                                                onClick={() => setOpen(false)}
-                                        >
-                                                ✕
-                                        </button>
-                                        <span className="theme-label">Workspaces</span>
-                                        <div className="mobile-workspaces">
-                                                {workspaces.length === 0 && (
-                                                        <span>No workspaces yet</span>
-                                                )}
-                                                {workspaces.map((w) => (
-                                                        <Link
-                                                                key={w.id}
-                                                                to={`/workspace/${w.id}`}
-                                                                className={
-                                                                        w.id === currentWsId
-                                                                                ? "workspace-link active"
-                                                                                : "workspace-link"
-                                                                }
-                                                                onClick={() => setOpen(false)}
-                                                        >
-                                                                {w.name || "Untitled"}
-                                                        </Link>
-                                                ))}
-                                        </div>
-                                        <div className="mobile-workspace-create">
-                                                <input
-                                                        className="workspace-bar-input"
-                                                        value={name}
-                                                        onChange={(e) => setName(e.target.value)}
-                                                        placeholder="New workspace name"
-                                                />
-                                                <Button
-                                                        onClick={async () => {
-                                                                const n = name.trim();
-                                                                if (!n) return;
-                                                                await createWorkspace(n);
-                                                                setName("");
-                                                                setOpen(false);
-                                                        }}
-                                                >
-                                                        Create
-                                                </Button>
-                                        </div>
-                                        <AuthPanel
-                                                user={user}
-                                                auth={auth}
-                                                provider={provider}
-                                        />
-                                        <label className="theme-label">Theme</label>
-                                        <select
-                                                className="theme-select"
-                                                value={paletteKey}
-                                                onChange={(e) => setPaletteKey(e.target.value)}
-                                        >
-                                                {Object.entries(PALETTES).map(([k, v]) => (
-                                                        <option key={k} value={k}>
-                                                                {v.name}
-                                                        </option>
-                                                ))}
-                                        </select>
-                                </div>
-                        </div>
-                </div>
-        );
+	const [open, setOpen] = useState(false);
+	const [name, setName] = useState("");
+	return (
+		<div className="mobile-menu-container">
+			<button
+				className="mobile-menu-button"
+				onClick={() => setOpen(true)}
+			>
+				☰
+			</button>
+			<div
+				className={`mobile-menu-overlay ${open ? "open" : ""}`}
+				onClick={() => setOpen(false)}
+			>
+				<div
+					className="mobile-menu-drawer"
+					onClick={(e) => e.stopPropagation()}
+				>
+					<button
+						className="mobile-menu-close"
+						onClick={() => setOpen(false)}
+					>
+						✕
+					</button>
+					<span className="theme-label">Workspaces</span>
+					<div className="mobile-workspaces">
+						{workspaces.length === 0 && (
+							<span>No workspaces yet</span>
+						)}
+						{workspaces.map((w) => (
+							<Link
+								key={w.id}
+								to={`/workspace/${w.id}`}
+								className={
+									w.id === currentWsId
+										? "workspace-link active"
+										: "workspace-link"
+								}
+								onClick={() => setOpen(false)}
+							>
+								{w.name || "Untitled"}
+							</Link>
+						))}
+					</div>
+					<div className="mobile-workspace-create">
+						<input
+							className="workspace-bar-input"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="New workspace name"
+						/>
+						<Button
+							onClick={async () => {
+							const n = name.trim();
+							if (!n) return;
+							await createWorkspace(n);
+							setName("");
+							setOpen(false);
+						}}
+						>
+							Create
+						</Button>
+					</div>
+					<AuthPanel
+						user={user}
+						auth={auth}
+					/>
+					<label className="theme-label">Theme</label>
+					<select
+						className="theme-select"
+						value={paletteKey}
+						onChange={(e) => setPaletteKey(e.target.value)}
+					>
+						{Object.entries(PALETTES).map(([k, v]) => (
+							<option key={k} value={k}>
+								{v.name}
+							</option>
+						))}
+					</select>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/src/create-profile.jsx
+++ b/src/create-profile.jsx
@@ -28,32 +28,34 @@ export default function CreateProfile() {
         return (
                 <div className="profile-page">
                         <Card title="Create Profile" right={null}>
-                                <input
-                                        className="auth-input"
-                                        type="text"
-                                        placeholder="Display Name"
-                                        value={displayName}
-                                        onChange={(e) => setDisplayName(e.target.value)}
-                                />
-                                <input
-                                        className="auth-input"
-                                        type="email"
-                                        placeholder="Email"
-                                        value={email}
-                                        onChange={(e) => setEmail(e.target.value)}
-                                />
-                                <input
-                                        className="auth-input"
-                                        type="password"
-                                        placeholder="Password"
-                                        value={password}
-                                        onChange={(e) => setPassword(e.target.value)}
-                                />
-                                <Button onClick={handleCreate}>Create Account</Button>
-                                {error && <div className="auth-error">{error}</div>}
-                                <Link to="/" className="auth-link">
-                                        Back
-                                </Link>
+                                <div className="auth-grid">
+                                        <input
+                                                className="auth-input"
+                                                type="text"
+                                                placeholder="Display Name"
+                                                value={displayName}
+                                                onChange={(e) => setDisplayName(e.target.value)}
+                                        />
+                                        <input
+                                                className="auth-input"
+                                                type="email"
+                                                placeholder="Email"
+                                                value={email}
+                                                onChange={(e) => setEmail(e.target.value)}
+                                        />
+                                        <input
+                                                className="auth-input"
+                                                type="password"
+                                                placeholder="Password"
+                                                value={password}
+                                                onChange={(e) => setPassword(e.target.value)}
+                                        />
+                                        <Button onClick={handleCreate}>Create Account</Button>
+                                        {error && <div className="auth-error">{error}</div>}
+                                        <Link to="/login" className="auth-link">
+                                                Back
+                                        </Link>
+                                </div>
                         </Card>
                 </div>
         );

--- a/src/login-page.jsx
+++ b/src/login-page.jsx
@@ -38,26 +38,28 @@ export default function LoginPage() {
         return (
                 <div className="profile-page">
                         <Card title="Login" right={null}>
-                                <input
-                                        className="auth-input"
-                                        type="email"
-                                        placeholder="Email"
-                                        value={email}
-                                        onChange={(e) => setEmail(e.target.value)}
-                                />
-                                <input
-                                        className="auth-input"
-                                        type="password"
-                                        placeholder="Password"
-                                        value={password}
-                                        onChange={(e) => setPassword(e.target.value)}
-                                />
-                                <Button onClick={handleEmailSignIn}>Login</Button>
-                                <Button onClick={handleGoogleSignIn}>Sign in with Google</Button>
-                                <Link to="/profile/new" className="auth-link">
-                                        Create account
-                                </Link>
-                                {error && <div className="auth-error">{error}</div>}
+                                <div className="auth-grid">
+                                        <input
+                                                className="auth-input"
+                                                type="email"
+                                                placeholder="Email"
+                                                value={email}
+                                                onChange={(e) => setEmail(e.target.value)}
+                                        />
+                                        <input
+                                                className="auth-input"
+                                                type="password"
+                                                placeholder="Password"
+                                                value={password}
+                                                onChange={(e) => setPassword(e.target.value)}
+                                        />
+                                        <Button onClick={handleEmailSignIn}>Login</Button>
+                                        <Button onClick={handleGoogleSignIn}>Sign in with Google</Button>
+                                        <Link to="/profile/new" className="auth-link">
+                                                Create account
+                                        </Link>
+                                        {error && <div className="auth-error">{error}</div>}
+                                </div>
                         </Card>
                 </div>
         );

--- a/src/login-page.jsx
+++ b/src/login-page.jsx
@@ -4,7 +4,7 @@ import {
 	signInWithEmailAndPassword,
 } from "firebase/auth";
 import { Link, useNavigate } from "react-router-dom";
-import { Button } from "./components/ui/ui";
+import { Card, Button } from "./components/ui/ui";
 import { auth, provider } from "./firebase";
 
 export default function LoginPage() {
@@ -35,29 +35,30 @@ export default function LoginPage() {
 		}
 	};
 
-	return (
-		<div className="auth-panel login-page">
-			<h2>Login</h2>
-			<input
-				className="auth-input"
-				type="email"
-				placeholder="Email"
-				value={email}
-				onChange={(e) => setEmail(e.target.value)}
-			/>
-			<input
-				className="auth-input"
-				type="password"
-				placeholder="Password"
-				value={password}
-				onChange={(e) => setPassword(e.target.value)}
-			/>
-			<Button onClick={handleEmailSignIn}>Login</Button>
-			<Button onClick={handleGoogleSignIn}>Google</Button>
-			<Link to="/profile/new" className="auth-link">
-				Create profile
-			</Link>
-			{error && <span className="auth-error">{error}</span>}
-		</div>
-	);
+        return (
+                <div className="profile-page">
+                        <Card title="Login" right={null}>
+                                <input
+                                        className="auth-input"
+                                        type="email"
+                                        placeholder="Email"
+                                        value={email}
+                                        onChange={(e) => setEmail(e.target.value)}
+                                />
+                                <input
+                                        className="auth-input"
+                                        type="password"
+                                        placeholder="Password"
+                                        value={password}
+                                        onChange={(e) => setPassword(e.target.value)}
+                                />
+                                <Button onClick={handleEmailSignIn}>Login</Button>
+                                <Button onClick={handleGoogleSignIn}>Sign in with Google</Button>
+                                <Link to="/profile/new" className="auth-link">
+                                        Create account
+                                </Link>
+                                {error && <div className="auth-error">{error}</div>}
+                        </Card>
+                </div>
+        );
 }

--- a/src/login-page.jsx
+++ b/src/login-page.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import {
+	signInWithPopup,
+	signInWithEmailAndPassword,
+} from "firebase/auth";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "./components/ui/ui";
+import { auth, provider } from "./firebase";
+
+export default function LoginPage() {
+	const [error, setError] = useState("");
+	const [email, setEmail] = useState("");
+	const [password, setPassword] = useState("");
+	const navigate = useNavigate();
+
+	const handleGoogleSignIn = async () => {
+		try {
+			setError("");
+			await signInWithPopup(auth, provider);
+			navigate("/");
+		} catch (e) {
+			console.error("sign-in failed", e);
+			setError("Sign in failed");
+		}
+	};
+
+	const handleEmailSignIn = async () => {
+		try {
+			setError("");
+			await signInWithEmailAndPassword(auth, email, password);
+			navigate("/");
+		} catch (e) {
+			console.error("email sign-in failed", e);
+			setError("Sign in failed");
+		}
+	};
+
+	return (
+		<div className="auth-panel login-page">
+			<h2>Login</h2>
+			<input
+				className="auth-input"
+				type="email"
+				placeholder="Email"
+				value={email}
+				onChange={(e) => setEmail(e.target.value)}
+			/>
+			<input
+				className="auth-input"
+				type="password"
+				placeholder="Password"
+				value={password}
+				onChange={(e) => setPassword(e.target.value)}
+			/>
+			<Button onClick={handleEmailSignIn}>Login</Button>
+			<Button onClick={handleGoogleSignIn}>Google</Button>
+			<Link to="/profile/new" className="auth-link">
+				Create profile
+			</Link>
+			{error && <span className="auth-error">{error}</span>}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Extract sign-in UI into new LoginPage component
- Redirect unauthenticated visitors to `/login` and hide dashboard when logged out
- Replace header inline auth with login link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2a658f108326a74ed16dad72539c