### PR TITLE
feat: allow adding people by email

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -110,6 +110,12 @@ const currentWsId = location.pathname.startsWith("/workspace/")
        }, [user, location.pathname, navigate]);
 
        useEffect(() => {
+               if (user && location.pathname === "/login") {
+                       navigate("/");
+               }
+       }, [user, location.pathname, navigate]);
+
+       useEffect(() => {
                if (!user) {
                        setWorkspaces([]);
                         return;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import {
         query,
         where,
         getDocs,
+        getDoc,
+        setDoc,
 } from "firebase/firestore";
 import { Link, Routes, Route, useLocation, useNavigate } from "react-router-dom";
 import { db, auth } from "./firebase";
@@ -89,6 +91,24 @@ export default function App() {
                 const unsub = onAuthStateChanged(auth, setUser);
                 return () => unsub();
         }, []);
+
+       useEffect(() => {
+               if (!user) return;
+               (async () => {
+                       try {
+                               const pRef = doc(db, "profiles", user.uid);
+                               const snap = await getDoc(pRef);
+                               if (!snap.exists()) {
+                                       await setDoc(pRef, {
+                                               email: user.email?.toLowerCase() || "",
+                                               name: user.displayName || "",
+                                       });
+                               }
+                       } catch (err) {
+                               console.error("ensure profile failed", err);
+                       }
+               })();
+       }, [user]);
 
         const [banner, setBanner] = useState("");
         const [workspaces, setWorkspaces] = useState([]);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,9 +24,19 @@ import LoginPage from "./login-page";
 import { Card, Button } from "./components/ui/ui";
 import "./App.css";
 
-function WorkspaceNav({ workspaces, currentWsId, createWorkspace, deleteWorkspace, resetLocal, testConnection }) {
+function WorkspaceNav({
+        workspaces,
+        currentWsId,
+        currentUser,
+        createWorkspace,
+        deleteWorkspace,
+        resetLocal,
+        testConnection,
+}) {
         const [name, setName] = useState("");
         const navigate = useNavigate();
+        const current = workspaces.find((w) => w.id === currentWsId);
+        const role = current?.members?.[currentUser?.uid];
         return (
                 <div className="workspace-nav">
                         <Card title="Workspaces" right={null}>
@@ -54,7 +64,7 @@ function WorkspaceNav({ workspaces, currentWsId, createWorkspace, deleteWorkspac
                                                                 deleteWorkspace(currentWsId);
                                                         }
                                                 }}
-                                                disabled={!currentWsId}
+                                                disabled={!currentWsId || role !== "owner"}
                                         >
                                                 Delete workspace
                                         </Button>
@@ -186,6 +196,16 @@ const currentWsId = location.pathname.startsWith("/workspace/")
                                 memberIds: [uid],
                                 paletteKey: "royalViolet",
                         });
+                        await setDoc(
+                                doc(db, "workspaces", d.id, "people", uid),
+                                {
+                                        uid,
+                                        email: auth.currentUser.email?.toLowerCase() || "",
+                                        name: auth.currentUser.displayName || "",
+                                        role: "owner",
+                                        createdAt: serverTimestamp(),
+                                },
+                        );
                         setWorkspaces((prev) =>
                                 prev.map((w) => (w.id === tempId ? { ...w, id: d.id } : w)),
                         );
@@ -278,6 +298,7 @@ const currentWsId = location.pathname.startsWith("/workspace/")
                                        <WorkspaceNav
                                                workspaces={workspaces}
                                                currentWsId={currentWsId}
+                                               currentUser={user}
                                                createWorkspace={createWorkspace}
                                                deleteWorkspace={deleteWorkspace}
                                                resetLocal={resetLocal}

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -14,6 +14,7 @@ export default function List({
         computeDerivedPercent = () => ({ percent: 0, count: 0 }),
         onSelectItem,
         selectedId,
+        children,
 }) {
         return (
                 <Card
@@ -86,7 +87,12 @@ export default function List({
 
                                                 {isPeople && (
                                                         <>
-                                                                <span>{item.name}</span>
+                                                                <span>
+                                                                        {item.name}
+                                                                        {item.email
+                                                                                ? ` (${item.email})`
+                                                                                : ""}
+                                                                </span>
                                                                 <select
                                                                         className="status-select"
                                                                         value={item.status || "watching"}
@@ -114,21 +120,20 @@ export default function List({
                                         </div>
                                 );
                         })}
-
-                        {!readOnly && (
+                        {!readOnly && type !== "people" && (
                                 <AddRow
                                         type={type}
                                         placeholder={
-                                                type === "people"
-                                                        ? "Add a person/project"
-                                                        : type === "goals"
-                                                                ? "Add a goal"
-                                                                : "Add a project"
+                                                type === "goals"
+                                                        ? "Add a goal"
+                                                        : "Add a project"
                                         }
                                         disabled={readOnly}
                                         onAdd={onAdd}
                                 />
                         )}
+
+                        {children}
                 </Card>
         );
 }

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -11,6 +11,8 @@ export default function List({
         onDelete,
         paletteKey,
         readOnly,
+        canAdd = true,
+        canDelete = true,
         computeDerivedPercent = () => ({ percent: 0, count: 0 }),
         onSelectItem,
         selectedId,
@@ -45,7 +47,7 @@ export default function List({
                                                                 <span>{item.name}</span>
                                                                 <div className="list-actions">
                                                                         <div className="list-value">{derived}%</div>
-                                                                        {!readOnly && (
+                                                                        {!readOnly && canDelete && (
                                                                                 <button
                                                                                         onClick={() => onDelete(item.id)}
                                                                                         className="delete-button"
@@ -74,7 +76,7 @@ export default function List({
                                                                         <option value="doing">Doing</option>
                                                                         <option value="done">Done</option>
                                                                 </select>
-                                                                {!readOnly && (
+                                                                {!readOnly && canDelete && (
                                                                         <button
                                                                                 onClick={() => onDelete(item.id)}
                                                                                 className="delete-button"
@@ -93,19 +95,19 @@ export default function List({
                                                                 </span>
                                                                 <select
                                                                         className="status-select"
-                                                                        value={item.status || "watching"}
+                                                                        value={item.role || "collaborator"}
                                                                         onChange={(e) =>
                                                                                 onUpdate(item.id, {
-                                                                                        status: e.target.value,
+                                                                                        role: e.target.value,
                                                                                 })
                                                                         }
-                                                                        disabled={readOnly}
+                                                                        disabled={readOnly || item.role === "owner"}
                                                                 >
-                                                                        <option value="watching">watching</option>
-                                                                        <option value="ongoing">ongoing</option>
-                                                                        <option value="completed">completed</option>
+                                                                        <option value="admin">admin</option>
+                                                                        <option value="editor">editor</option>
+                                                                        <option value="collaborator">collaborator</option>
                                                                 </select>
-                                                                {!readOnly && (
+                                                                {!readOnly && canDelete && item.role !== "owner" && (
                                                                         <button
                                                                                 onClick={() => onDelete(item.id)}
                                                                                 className="delete-button"
@@ -118,7 +120,7 @@ export default function List({
                                         </div>
                                 );
                         })}
-                        {!readOnly && type !== "people" && (
+                        {!readOnly && canAdd && type !== "people" && (
                                 <AddRow
                                         type={type}
                                         placeholder={

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -88,10 +88,8 @@ export default function List({
                                                 {isPeople && (
                                                         <>
                                                                 <span>
-                                                                        {item.name}
-                                                                        {item.email
-                                                                                ? ` (${item.email})`
-                                                                                : ""}
+                                                                        {item.name || item.email}
+                                                                        {item.name && item.email ? ` (${item.email})` : ""}
                                                                 </span>
                                                                 <select
                                                                         className="status-select"

--- a/src/components/people-overview/add-person.jsx
+++ b/src/components/people-overview/add-person.jsx
@@ -9,8 +9,10 @@ export default function AddPerson({ onAdd, disabled }) {
         const handleSubmit = () => {
                 const n = name.trim();
                 const e = email.trim();
-                if (!n || !e) return;
-                onAdd({ name: n, email: e, status });
+                if (!e) return;
+                const payload = { email: e, status };
+                if (n) payload.name = n;
+                onAdd(payload);
                 setName("");
                 setEmail("");
                 setStatus("watching");
@@ -28,7 +30,7 @@ export default function AddPerson({ onAdd, disabled }) {
                                 onKeyDown={(e) => {
                                         if (e.key === "Enter") handleSubmit();
                                 }}
-                                placeholder="Name"
+                                placeholder="Name (optional)"
                         />
                         <input
                                 disabled={disabled}

--- a/src/components/people-overview/add-person.jsx
+++ b/src/components/people-overview/add-person.jsx
@@ -8,7 +8,7 @@ export default function AddPerson({ onAdd, disabled }) {
 
         const handleSubmit = () => {
                 const n = name.trim();
-                const e = email.trim();
+                const e = email.trim().toLowerCase();
                 if (!e) return;
                 const payload = { email: e, status };
                 if (n) payload.name = n;

--- a/src/components/people-overview/add-person.jsx
+++ b/src/components/people-overview/add-person.jsx
@@ -4,18 +4,18 @@ import "../ui/ui.css";
 export default function AddPerson({ onAdd, disabled }) {
         const [name, setName] = useState("");
         const [email, setEmail] = useState("");
-        const [status, setStatus] = useState("watching");
+        const [role, setRole] = useState("collaborator");
 
         const handleSubmit = () => {
                 const n = name.trim();
                 const e = email.trim().toLowerCase();
                 if (!e) return;
-                const payload = { email: e, status };
+                const payload = { email: e, role };
                 if (n) payload.name = n;
                 onAdd(payload);
                 setName("");
                 setEmail("");
-                setStatus("watching");
+                setRole("collaborator");
         };
 
         return (
@@ -44,15 +44,15 @@ export default function AddPerson({ onAdd, disabled }) {
                         />
                         <select
                                 disabled={disabled}
-                                value={status}
-                                onChange={(e) => setStatus(e.target.value)}
+                                value={role}
+                                onChange={(e) => setRole(e.target.value)}
                                 onKeyDown={(e) => {
                                         if (e.key === "Enter") handleSubmit();
                                 }}
                         >
-                                <option value="watching">watching</option>
-                                <option value="ongoing">ongoing</option>
-                                <option value="completed">completed</option>
+                                <option value="admin">admin</option>
+                                <option value="editor">editor</option>
+                                <option value="collaborator">collaborator</option>
                         </select>
                         <button onClick={handleSubmit} disabled={disabled}>
                                 Add

--- a/src/components/people-overview/add-person.jsx
+++ b/src/components/people-overview/add-person.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import "../ui/ui.css";
+
+export default function AddPerson({ onAdd, disabled }) {
+        const [name, setName] = useState("");
+        const [email, setEmail] = useState("");
+        const [status, setStatus] = useState("watching");
+
+        const handleSubmit = () => {
+                const n = name.trim();
+                const e = email.trim();
+                if (!n || !e) return;
+                onAdd({ name: n, email: e, status });
+                setName("");
+                setEmail("");
+                setStatus("watching");
+        };
+
+        return (
+                <div
+                        className="add-row"
+                        style={{ gridTemplateColumns: "1fr 1fr auto auto" }}
+                >
+                        <input
+                                disabled={disabled}
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                onKeyDown={(e) => {
+                                        if (e.key === "Enter") handleSubmit();
+                                }}
+                                placeholder="Name"
+                        />
+                        <input
+                                disabled={disabled}
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                                onKeyDown={(e) => {
+                                        if (e.key === "Enter") handleSubmit();
+                                }}
+                                placeholder="Email"
+                                type="email"
+                        />
+                        <select
+                                disabled={disabled}
+                                value={status}
+                                onChange={(e) => setStatus(e.target.value)}
+                                onKeyDown={(e) => {
+                                        if (e.key === "Enter") handleSubmit();
+                                }}
+                        >
+                                <option value="watching">watching</option>
+                                <option value="ongoing">ongoing</option>
+                                <option value="completed">completed</option>
+                        </select>
+                        <button onClick={handleSubmit} disabled={disabled}>
+                                Add
+                        </button>
+                </div>
+        );
+}

--- a/src/components/people-overview/people-overview.jsx
+++ b/src/components/people-overview/people-overview.jsx
@@ -2,7 +2,16 @@ import React from "react";
 import List from "../list/list";
 import AddPerson from "./add-person";
 
-export default function PeopleOverview({ data, onAdd, onUpdate, onDelete, readOnly, ...rest }) {
+export default function PeopleOverview({
+        data,
+        onAdd,
+        onUpdate,
+        onDelete,
+        readOnly,
+        canAdd = false,
+        canDelete = false,
+        ...rest
+}) {
         return (
                 <List
                         title="Tracked People Projects"
@@ -11,9 +20,13 @@ export default function PeopleOverview({ data, onAdd, onUpdate, onDelete, readOn
                         onUpdate={onUpdate}
                         onDelete={onDelete}
                         readOnly={readOnly}
+                        canAdd={canAdd}
+                        canDelete={canDelete}
                         {...rest}
                 >
-                        {!readOnly && <AddPerson onAdd={onAdd} disabled={readOnly} />}
+                        {canAdd && !readOnly && (
+                                <AddPerson onAdd={onAdd} disabled={readOnly} />
+                        )}
                 </List>
         );
 }

--- a/src/components/people-overview/people-overview.jsx
+++ b/src/components/people-overview/people-overview.jsx
@@ -1,6 +1,19 @@
 import React from "react";
 import List from "../list/list";
+import AddPerson from "./add-person";
 
-export default function PeopleOverview(props) {
-	return <List title="Tracked People Projects" type="people" {...props} />;
+export default function PeopleOverview({ data, onAdd, onUpdate, onDelete, readOnly, ...rest }) {
+        return (
+                <List
+                        title="Tracked People Projects"
+                        type="people"
+                        data={data}
+                        onUpdate={onUpdate}
+                        onDelete={onDelete}
+                        readOnly={readOnly}
+                        {...rest}
+                >
+                        {!readOnly && <AddPerson onAdd={onAdd} disabled={readOnly} />}
+                </List>
+        );
 }

--- a/src/components/ui/ui.jsx
+++ b/src/components/ui/ui.jsx
@@ -36,7 +36,6 @@ export function AddRow({ type, onAdd, disabled, placeholder }) {
 	const handleSubmit = () => {
 		const v = text.trim();
 		if (!v) return;
-                if (type === "people") onAdd({ name: v, status: "watching" });
                 if (type === "projects") onAdd({ name: v, percent: 0 });
                 if (type === "goals") onAdd({ title: v, status: "todo" });
 		setText("");

--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -11,9 +11,12 @@ import {
         query,
         where,
         getDocs,
+        getDoc,
         arrayUnion,
+        arrayRemove,
+        deleteField,
 } from "firebase/firestore";
-import { db } from "./firebase";
+import { db, auth } from "./firebase";
 import ProjectsOverview from "./components/projects-overview/projects-overview";
 import PeopleOverview from "./components/people-overview/people-overview";
 import List from "./components/list/list";
@@ -25,6 +28,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
         const [people, setPeople] = useState([]);
         const [projectGoals, setProjectGoals] = useState({});
         const [selectedProjectId, setSelectedProjectId] = useState("");
+        const [role, setRole] = useState("collaborator");
 
         useEffect(() => {
                 if (!wsId) {
@@ -37,6 +41,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 const unsubWs = onSnapshot(base, (snap) => {
                         const data = snap.data();
                         if (data?.paletteKey) setPaletteKey(data.paletteKey);
+                        if (data?.members && auth.currentUser) {
+                                setRole(data.members[auth.currentUser.uid] || "collaborator");
+                        }
                 });
                 const unsubProjects = onSnapshot(collection(base, "projects"), (snap) =>
                         setProjects(snap.docs.map((d) => ({ id: d.id, ...d.data() }))),
@@ -65,8 +72,6 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 return () => unsubs.forEach((u) => u());
         }, [wsId, projects]);
 
-        const readOnly = !wsId;
-
         const getColRef = (colName) => {
                 if (!wsId) return null;
                 return collection(db, "workspaces", wsId, colName);
@@ -76,6 +81,21 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 if (!wsId || !projectId) return null;
                 return collection(db, "workspaces", wsId, "projects", projectId, "goals");
         };
+
+        const isOwner = role === "owner";
+        const isAdmin = role === "admin";
+        const isEditor = role === "editor";
+
+        const canManageUsers = isOwner || isAdmin;
+        const canAddProject = isOwner || isAdmin;
+        const canDeleteProject = isOwner || isAdmin;
+        const canAddGoal = isOwner || isAdmin || isEditor;
+        const canDeleteGoal = isOwner || isAdmin || isEditor;
+        const canEditGoal = canAddGoal || role === "collaborator";
+
+        const projectReadOnly = !wsId || !(canAddProject || canDeleteProject);
+        const goalReadOnly = !wsId || !canEditGoal;
+        const peopleReadOnly = !wsId || !canManageUsers;
 
         async function addItem(colName, item) {
                 const ref = getColRef(colName);
@@ -96,15 +116,17 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         return "";
                                 }
                                 const uid = snap.docs[0].id;
+                                const role = item.role || "collaborator";
                                 const wsRef = doc(db, "workspaces", wsId);
                                 await updateDoc(wsRef, {
-                                        [`members.${uid}`]: "editor",
+                                        [`members.${uid}`]: role,
                                         memberIds: arrayUnion(uid),
                                 });
                                 const d = await addDoc(ref, {
                                         ...item,
                                         email,
                                         uid,
+                                        role,
                                         createdAt: serverTimestamp(),
                                 });
                                 return d.id;
@@ -128,6 +150,12 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         return;
                 }
                 try {
+                        if (colName === "people" && patch.role) {
+                                const snap = await getDoc(doc(ref, id));
+                                const uid = snap.data().uid;
+                                const wsRef = doc(db, "workspaces", wsId);
+                                await updateDoc(wsRef, { [`members.${uid}`]: patch.role });
+                        }
                         await updateDoc(doc(ref, id), patch);
                 } catch (err) {
                         if (err.code !== "not-found") {
@@ -142,6 +170,15 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         return;
                 }
                 try {
+                        if (colName === "people") {
+                                const snap = await getDoc(doc(ref, id));
+                                const uid = snap.data().uid;
+                                const wsRef = doc(db, "workspaces", wsId);
+                                await updateDoc(wsRef, {
+                                        [`members.${uid}`]: deleteField(),
+                                        memberIds: arrayRemove(uid),
+                                });
+                        }
                         await deleteDoc(doc(ref, id));
                 } catch (err) {
                         setBanner(`Delete failed: ${err.message}`);
@@ -221,7 +258,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         onAdd={(item) => addItem("projects", item)}
                                         onUpdate={(id, patch) => updateItem("projects", id, patch)}
                                         onDelete={(id) => deleteItem("projects", id)}
-                                        readOnly={readOnly}
+                                        readOnly={projectReadOnly}
+                                        canAdd={canAddProject}
+                                        canDelete={canDeleteProject}
                                         computeDerivedPercent={computeDerivedPercent}
                                         selectedId={selectedProjectId}
                                         onSelectItem={(id) =>
@@ -239,7 +278,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                                 onAdd={(item) => addGoalToProject(selectedProjectId, item)}
                                                 onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
                                                 onDelete={(id) => deleteGoal(selectedProjectId, id)}
-                                                readOnly={readOnly}
+                                                readOnly={goalReadOnly}
+                                                canAdd={canAddGoal}
+                                                canDelete={canDeleteGoal}
                                         />
                                 ) : (
                                         <Card title="Goals">
@@ -253,7 +294,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         onAdd={(item) => addItem("people", item)}
                                         onUpdate={(id, patch) => updateItem("people", id, patch)}
                                         onDelete={(id) => deleteItem("people", id)}
-                                        readOnly={readOnly}
+                                        readOnly={peopleReadOnly}
+                                        canAdd={canManageUsers}
+                                        canDelete={canManageUsers}
                                 />
                         </div>
 

--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -85,9 +85,10 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                 }
                 try {
                         if (colName === "people") {
+                                const email = item.email.toLowerCase();
                                 const q = query(
                                         collection(db, "profiles"),
-                                        where("email", "==", item.email),
+                                        where("email", "==", email),
                                 );
                                 const snap = await getDocs(q);
                                 if (snap.empty) {
@@ -102,6 +103,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                 });
                                 const d = await addDoc(ref, {
                                         ...item,
+                                        email,
                                         uid,
                                         createdAt: serverTimestamp(),
                                 });

--- a/src/workspace-page.jsx
+++ b/src/workspace-page.jsx
@@ -8,6 +8,10 @@ import {
         doc,
         onSnapshot,
         serverTimestamp,
+        query,
+        where,
+        getDocs,
+        arrayUnion,
 } from "firebase/firestore";
 import { db } from "./firebase";
 import ProjectsOverview from "./components/projects-overview/projects-overview";
@@ -80,7 +84,34 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         return "";
                 }
                 try {
-                        const d = await addDoc(ref, { ...item, createdAt: serverTimestamp() });
+                        if (colName === "people") {
+                                const q = query(
+                                        collection(db, "profiles"),
+                                        where("email", "==", item.email),
+                                );
+                                const snap = await getDocs(q);
+                                if (snap.empty) {
+                                        setBanner("User not found");
+                                        return "";
+                                }
+                                const uid = snap.docs[0].id;
+                                const wsRef = doc(db, "workspaces", wsId);
+                                await updateDoc(wsRef, {
+                                        [`members.${uid}`]: "editor",
+                                        memberIds: arrayUnion(uid),
+                                });
+                                const d = await addDoc(ref, {
+                                        ...item,
+                                        uid,
+                                        createdAt: serverTimestamp(),
+                                });
+                                return d.id;
+                        }
+
+                        const d = await addDoc(ref, {
+                                ...item,
+                                createdAt: serverTimestamp(),
+                        });
                         return d.id;
                 } catch (err) {
                         setBanner(`Add failed: ${err.message}`);


### PR DESCRIPTION
## Summary
- capture a person's name and email in AddPerson
- display emails in people list and drop AddRow support for people
- grant workspace access when a person is added by email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac4eaaaf448326a7ee4b2af6882642