### PR TITLE
refactor: reorganize pages and styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,38 +98,3 @@
 .accent {
         color: var(--accent);
 }
-
-.palette-royalViolet {
-        --bg: #1b1b2f;
-        --card: #2c2c3e;
-        --text: #f1f1f8;
-        --accent: #9d4edd;
-        --accent-subtle: #c77dff;
-}
-
-.palette-coralSpark {
-        --bg: #202124;
-        --card: #2f3136;
-        --text: #eeeeee;
-        --accent: #ff6b6b;
-        --accent-subtle: #ff9f80;
-}
-
-.palette-neonCyan {
-        --bg: #0d1b2a;
-        --card: #1b263b;
-        --text: #e0e1dd;
-        --accent: #00b4d8;
-        --accent-subtle: #90e0ef;
-}
-
-.profile-page {
-        display: flex;
-        justify-content: center;
-        margin-top: 40px;
-}
-
-.auth-grid {
-        display: grid;
-        gap: 12px;
-}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,10 +17,10 @@ import {
 import { Link, Routes, Route, useLocation, useNavigate } from "react-router-dom";
 import { db, auth } from "./firebase";
 import Header from "./components/header/header";
-import WorkspacePage from "./workspace-page";
-import CreateProfile from "./create-profile";
-import EditProfile from "./edit-profile";
-import LoginPage from "./login-page";
+import WorkspacePage from "./pages/workspace";
+import CreateProfile from "./pages/create-profile";
+import EditProfile from "./pages/edit-profile";
+import LoginPage from "./pages/login";
 import { Card, Button } from "./components/ui/ui";
 import "./App.css";
 

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -38,16 +38,8 @@
 	align-items: center;
 }
 
-.auth-input {
-	background: transparent;
-	color: var(--text);
-	border: 1px solid var(--accent);
-	border-radius: 8px;
-	padding: 6px 8px;
-}
-
 .greeting {
-	opacity: 0.85;
+        opacity: 0.85;
 }
 
 .auth-error {

--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -1,8 +1,8 @@
 .header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	position: relative;
 }
 
 .header-title {
@@ -39,86 +39,87 @@
 }
 
 .greeting {
-        opacity: 0.85;
+	opacity: 0.85;
 }
 
 .auth-error {
-        color: var(--accent);
+	color: var(--accent);
 }
 
 .mobile-menu-container {
-        display: none;
+	display: none;
 }
 
 .mobile-menu-button {
-        background: transparent;
-        border: none;
-        color: var(--text);
-        font-size: 24px;
+	background: transparent;
+	border: none;
+	color: var(--text);
+	font-size: 24px;
 }
 
 .mobile-menu-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.3);
-        display: none;
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.3);
+	display: none;
 }
 
 .mobile-menu-overlay.open {
-        display: block;
+	display: block;
 }
 
 .mobile-menu-drawer {
-        position: absolute;
-        top: 0;
-        right: 0;
-        width: 80%;
-        max-width: 300px;
-        height: 100%;
-        background: var(--bg);
-        border-left: 1px solid var(--accent);
-        padding: 16px;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        transform: translateX(100%);
-        transition: transform 0.3s ease;
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 80%;
+	max-width: 300px;
+	height: 100%;
+	background: var(--bg);
+	border-left: 1px solid var(--accent);
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	transform: translateX(100%);
+transition: transform 0.3s ease;
 }
 
 .mobile-menu-overlay.open .mobile-menu-drawer {
-        transform: translateX(0);
+	transform: translateX(0);
 }
 
 .mobile-menu-close {
-        background: transparent;
-        border: none;
-        color: var(--text);
-        font-size: 24px;
-        align-self: flex-end;
+	background: transparent;
+	border: none;
+	color: var(--text);
+	font-size: 24px;
+	align-self: flex-end;
 }
 
 .mobile-workspaces {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
 .mobile-workspace-create {
-        display: flex;
-        gap: 8px;
-        margin-top: 8px;
+	display: flex;
+	gap: 8px;
+	margin-top: 8px;
 }
 
 .auth-link {
-        color: var(--accent);
+	color: var(--accent);
 }
 
-@media (max-width: 600px) {
-        .header-controls {
-                display: none;
-        }
+@media (max-width: 768px) {
+	.header-controls {
+			display: none;
+	}
 
-        .mobile-menu-container {
-                display: block;
-        }
+	.mobile-menu-container {
+		display: block;
+		z-index: 999;
+	}
 }

--- a/src/components/people-overview/add-person.jsx
+++ b/src/components/people-overview/add-person.jsx
@@ -21,7 +21,6 @@ export default function AddPerson({ onAdd, disabled }) {
         return (
                 <div
                         className="add-row"
-                        style={{ gridTemplateColumns: "1fr 1fr auto auto" }}
                 >
                         <input
                                 disabled={disabled}

--- a/src/components/people-overview/people-overview.css
+++ b/src/components/people-overview/people-overview.css
@@ -1,3 +1,23 @@
 .people-overview {
         position: relative;
 }
+
+.people-overview .add-row {
+	grid-template-columns: 1fr 1fr auto auto;
+}
+
+.people-overview .add-row input,
+.people-overview .add-row select {
+	background: transparent;
+    color: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    padding: 8px 10px;
+}
+
+@media screen and (max-width: 768px) {
+	.people-overview .add-row {
+		display: grid;
+		grid-template-columns: 1fr;
+	}
+}

--- a/src/components/people-overview/people-overview.css
+++ b/src/components/people-overview/people-overview.css
@@ -1,0 +1,3 @@
+.people-overview {
+        position: relative;
+}

--- a/src/components/people-overview/people-overview.jsx
+++ b/src/components/people-overview/people-overview.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import List from "../list/list";
 import AddPerson from "./add-person";
+import "./people-overview.css";
 
 export default function PeopleOverview({
         data,
@@ -13,20 +14,22 @@ export default function PeopleOverview({
         ...rest
 }) {
         return (
-                <List
-                        title="Tracked People Projects"
-                        type="people"
-                        data={data}
-                        onUpdate={onUpdate}
-                        onDelete={onDelete}
-                        readOnly={readOnly}
-                        canAdd={canAdd}
-                        canDelete={canDelete}
-                        {...rest}
-                >
-                        {canAdd && !readOnly && (
-                                <AddPerson onAdd={onAdd} disabled={readOnly} />
-                        )}
-                </List>
+                <div className="people-overview">
+                        <List
+                                title="Tracked People Projects"
+                                type="people"
+                                data={data}
+                                onUpdate={onUpdate}
+                                onDelete={onDelete}
+                                readOnly={readOnly}
+                                canAdd={canAdd}
+                                canDelete={canDelete}
+                                {...rest}
+                        >
+                                {canAdd && !readOnly && (
+                                        <AddPerson onAdd={onAdd} disabled={readOnly} />
+                                )}
+                        </List>
+                </div>
         );
 }

--- a/src/components/projects-overview/projects-overview.css
+++ b/src/components/projects-overview/projects-overview.css
@@ -1,0 +1,37 @@
+.projects-empty {
+        opacity: 0.7;
+}
+
+.project-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 12px;
+        align-items: center;
+        padding: 10px 0;
+        border-bottom: 1px dashed var(--accent);
+}
+
+.project-row.selected {
+        background: var(--accent-subtle);
+        color: #fff;
+}
+
+.project-actions {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+}
+
+.project-progress {
+        text-align: right;
+        color: var(--accent);
+}
+
+.delete-button {
+        color: #ff4d4f;
+        background: transparent;
+        border: 1px solid #ff4d4f;
+        border-radius: 8px;
+        padding: 4px 8px;
+}

--- a/src/components/projects-overview/projects-overview.jsx
+++ b/src/components/projects-overview/projects-overview.jsx
@@ -1,6 +1,59 @@
 import React from "react";
-import List from "../list/list";
+import { Card, AddRow } from "../ui/ui";
+import "./projects-overview.css";
 
-export default function ProjectsOverview(props) {
-	return <List title="Projects" type="projects" {...props} />;
+export default function ProjectsOverview({
+        data,
+        onAdd,
+        onDelete,
+        readOnly,
+        canAdd = true,
+        canDelete = true,
+        computeDerivedPercent = () => ({ percent: 0 }),
+        selectedId,
+        onSelectItem,
+        onUpdate,
+}) {
+        return (
+                <Card
+                        title="Projects"
+                        right={readOnly ? <span className="muted">Read only</span> : null}
+                >
+                        {!data.length && <div className="projects-empty">No projects</div>}
+
+                        {data.map((item) => (
+                                <div
+                                        key={item.id}
+                                        className={`project-row ${
+                                                selectedId === item.id ? "selected" : ""
+                                        }`}
+                                        onClick={() => onSelectItem && onSelectItem(item.id)}
+                                >
+                                        <span>{item.name}</span>
+                                        <div className="project-actions">
+                                                <div className="project-progress">
+                                                        {computeDerivedPercent(item.id).percent}%
+                                                </div>
+                                                {!readOnly && canDelete && (
+                                                        <button
+                                                                onClick={() => onDelete(item.id)}
+                                                                className="delete-button"
+                                                        >
+                                                                Delete
+                                                        </button>
+                                                )}
+                                        </div>
+                                </div>
+                        ))}
+
+                        {!readOnly && canAdd && (
+                                <AddRow
+                                        type="projects"
+                                        placeholder="Add a project"
+                                        onAdd={onAdd}
+                                        disabled={readOnly}
+                                />
+                        )}
+                </Card>
+        );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
 import "./index.css";
+import "./styles/palette.css";
 import { registerSW } from "./registerSW.js";
 
 registerSW();

--- a/src/pages/create-profile/create-profile.css
+++ b/src/pages/create-profile/create-profile.css
@@ -1,0 +1,26 @@
+.profile-page {
+        display: flex;
+        justify-content: center;
+        margin-top: 40px;
+}
+
+.auth-grid {
+        display: grid;
+        gap: 12px;
+}
+
+.auth-input {
+        background: transparent;
+        color: var(--text);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 6px 8px;
+}
+
+.auth-link {
+        color: var(--accent);
+}
+
+.auth-error {
+        color: var(--accent);
+}

--- a/src/pages/create-profile/index.jsx
+++ b/src/pages/create-profile/index.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
-import { auth } from "./firebase";
-import { Card, Button } from "./components/ui/ui";
+import { auth } from "../../firebase";
+import { Card, Button } from "../../components/ui/ui";
 import { useNavigate, Link } from "react-router-dom";
+import "./create-profile.css";
 
 export default function CreateProfile() {
         const [displayName, setDisplayName] = useState("");
@@ -14,7 +15,11 @@ export default function CreateProfile() {
         const handleCreate = async () => {
                 try {
                         setError("");
-                        const cred = await createUserWithEmailAndPassword(auth, email, password);
+                        const cred = await createUserWithEmailAndPassword(
+                                auth,
+                                email,
+                                password,
+                        );
                         if (displayName) {
                                 await updateProfile(cred.user, { displayName });
                         }

--- a/src/pages/edit-profile/edit-profile.css
+++ b/src/pages/edit-profile/edit-profile.css
@@ -1,0 +1,26 @@
+.profile-page {
+        display: flex;
+        justify-content: center;
+        margin-top: 40px;
+}
+
+.auth-input {
+        background: transparent;
+        color: var(--text);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 6px 8px;
+        margin-bottom: 12px;
+}
+
+.auth-link {
+        color: var(--accent);
+}
+
+.auth-error {
+        color: var(--accent);
+}
+
+.greeting {
+        opacity: 0.85;
+}

--- a/src/pages/edit-profile/index.jsx
+++ b/src/pages/edit-profile/index.jsx
@@ -4,9 +4,10 @@ import {
         updateEmail,
         updatePassword,
 } from "firebase/auth";
-import { auth } from "./firebase";
-import { Card, Button } from "./components/ui/ui";
+import { auth } from "../../firebase";
+import { Card, Button } from "../../components/ui/ui";
 import { useNavigate } from "react-router-dom";
+import "./edit-profile.css";
 
 export default function EditProfile() {
         const user = auth.currentUser;

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,39 +1,40 @@
 import React, { useState } from "react";
 import {
-	signInWithPopup,
-	signInWithEmailAndPassword,
+        signInWithPopup,
+        signInWithEmailAndPassword,
 } from "firebase/auth";
 import { Link, useNavigate } from "react-router-dom";
-import { Card, Button } from "./components/ui/ui";
-import { auth, provider } from "./firebase";
+import { Card, Button } from "../../components/ui/ui";
+import { auth, provider } from "../../firebase";
+import "./login.css";
 
 export default function LoginPage() {
-	const [error, setError] = useState("");
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
-	const navigate = useNavigate();
+        const [error, setError] = useState("");
+        const [email, setEmail] = useState("");
+        const [password, setPassword] = useState("");
+        const navigate = useNavigate();
 
-	const handleGoogleSignIn = async () => {
-		try {
-			setError("");
-			await signInWithPopup(auth, provider);
-			navigate("/");
-		} catch (e) {
-			console.error("sign-in failed", e);
-			setError("Sign in failed");
-		}
-	};
+        const handleGoogleSignIn = async () => {
+                try {
+                        setError("");
+                        await signInWithPopup(auth, provider);
+                        navigate("/");
+                } catch (e) {
+                        console.error("sign-in failed", e);
+                        setError("Sign in failed");
+                }
+        };
 
-	const handleEmailSignIn = async () => {
-		try {
-			setError("");
-			await signInWithEmailAndPassword(auth, email, password);
-			navigate("/");
-		} catch (e) {
-			console.error("email sign-in failed", e);
-			setError("Sign in failed");
-		}
-	};
+        const handleEmailSignIn = async () => {
+                try {
+                        setError("");
+                        await signInWithEmailAndPassword(auth, email, password);
+                        navigate("/");
+                } catch (e) {
+                        console.error("email sign-in failed", e);
+                        setError("Sign in failed");
+                }
+        };
 
         return (
                 <div className="profile-page">

--- a/src/pages/login/login.css
+++ b/src/pages/login/login.css
@@ -1,0 +1,26 @@
+.profile-page {
+        display: flex;
+        justify-content: center;
+        margin-top: 40px;
+}
+
+.auth-grid {
+        display: grid;
+        gap: 12px;
+}
+
+.auth-input {
+        background: transparent;
+        color: var(--text);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 6px 8px;
+}
+
+.auth-link {
+        color: var(--accent);
+}
+
+.auth-error {
+        color: var(--accent);
+}

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -16,11 +16,12 @@ import {
         arrayRemove,
         deleteField,
 } from "firebase/firestore";
-import { db, auth } from "./firebase";
-import ProjectsOverview from "./components/projects-overview/projects-overview";
-import PeopleOverview from "./components/people-overview/people-overview";
-import List from "./components/list/list";
-import { PALETTES, Card } from "./components/ui/ui";
+import { db, auth } from "../../firebase";
+import ProjectsOverview from "../../components/projects-overview/projects-overview";
+import PeopleOverview from "../../components/people-overview/people-overview";
+import List from "../../components/list/list";
+import { PALETTES, Card } from "../../components/ui/ui";
+import "./workspace.css";
 
 export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) {
         const { id: wsId } = useParams();
@@ -250,7 +251,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
         }, [projects, projectGoals]);
 
         return (
-                <>
+                <div className="workspace-page">
                         <div className="grid-wrap">
                                 <ProjectsOverview
                                         paletteKey={paletteKey}
@@ -305,7 +306,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         Palette: <span>{PALETTES[paletteKey].name}</span>
                                 </small>
                         </div>
-                </>
+                </div>
         );
 }
 

--- a/src/pages/workspace/workspace.css
+++ b/src/pages/workspace/workspace.css
@@ -1,0 +1,5 @@
+.workspace-page {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+}

--- a/src/styles/palette.css
+++ b/src/styles/palette.css
@@ -1,0 +1,23 @@
+.palette-royalViolet {
+        --bg: #1b1b2f;
+        --card: #2c2c3e;
+        --text: #f1f1f8;
+        --accent: #9d4edd;
+        --accent-subtle: #c77dff;
+}
+
+.palette-coralSpark {
+        --bg: #202124;
+        --card: #2f3136;
+        --text: #eeeeee;
+        --accent: #ff6b6b;
+        --accent-subtle: #ff9f80;
+}
+
+.palette-neonCyan {
+        --bg: #0d1b2a;
+        --card: #1b263b;
+        --text: #e0e1dd;
+        --accent: #00b4d8;
+        --accent-subtle: #90e0ef;
+}


### PR DESCRIPTION
## Summary
- split page components into dedicated folders with their own styles
- extract color palette into a reusable CSS file
- expand ProjectsOverview with standalone markup and styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "./firebase-config" from "src/firebase.js")*

------
https://chatgpt.com/codex/tasks/task_e_68acc46fe42c832698d442815f32db65