### PR TITLE
Improve email sign-in error messaging

### DIFF
--- a/src/login-page.jsx
+++ b/src/login-page.jsx
@@ -24,16 +24,24 @@ export default function LoginPage() {
 		}
 	};
 
-	const handleEmailSignIn = async () => {
-		try {
-			setError("");
-			await signInWithEmailAndPassword(auth, email, password);
-			navigate("/");
-		} catch (e) {
-			console.error("email sign-in failed", e);
-			setError("Sign in failed");
-		}
-	};
+        const handleEmailSignIn = async () => {
+                try {
+                        setError("");
+                        await signInWithEmailAndPassword(auth, email, password);
+                        navigate("/");
+                } catch (e) {
+                        console.error("email sign-in failed", e);
+                        if (
+                                e.code === "auth/wrong-password" ||
+                                e.code === "auth/user-not-found" ||
+                                e.code === "auth/invalid-email"
+                        ) {
+                                setError("Incorrect email or password.");
+                        } else {
+                                setError("Sign in failed");
+                        }
+                }
+        };
 
         return (
                 <div className="profile-page">


### PR DESCRIPTION
## Summary
- Clarify login failures by reporting specific message for wrong email or password

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "./firebase-config" from "src/firebase.js")*

------
https://chatgpt.com/codex/tasks/task_e_68acc0ab513083269fbe33e1e6297180