### PR TITLE
feat: reorganize mobile menu with profile and theme options

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -43,11 +43,15 @@
 }
 
 .auth-error {
-	color: var(--accent);
+        color: var(--accent);
+}
+
+.mobile-menu-heading {
+        opacity: 0.8;
 }
 
 .mobile-menu-container {
-	display: none;
+        display: none;
 }
 
 .mobile-menu-button {

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -37,7 +37,6 @@ export default function Header({
                                         paletteKey={paletteKey}
                                         setPaletteKey={setPaletteKey}
                                         user={user}
-                                        auth={auth}
                                         workspaces={workspaces}
                                         currentWsId={currentWsId}
                                         createWorkspace={createWorkspace}

--- a/src/components/header/mobile-menu.jsx
+++ b/src/components/header/mobile-menu.jsx
@@ -1,16 +1,14 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { PALETTES, Button } from "../ui/ui";
-import AuthPanel from "./auth-panel";
 
 export default function MobileMenu({
-	paletteKey,
-	setPaletteKey,
-	user,
-	auth,
-	workspaces,
-	currentWsId,
-	createWorkspace,
+        paletteKey,
+        setPaletteKey,
+        user,
+        workspaces,
+        currentWsId,
+        createWorkspace,
 }) {
 	const [open, setOpen] = useState(false);
 	const [name, setName] = useState("");
@@ -30,69 +28,82 @@ export default function MobileMenu({
 					className="mobile-menu-drawer"
 					onClick={(e) => e.stopPropagation()}
 				>
-					<button
-						className="mobile-menu-close"
-						onClick={() => setOpen(false)}
-					>
-						✕
-					</button>
-					<span className="theme-label">Workspaces</span>
-					<div className="mobile-workspaces">
-						{workspaces.length === 0 && (
-							<span>No workspaces yet</span>
-						)}
-						{workspaces.map((w) => (
-							<Link
-								key={w.id}
-								to={`/workspace/${w.id}`}
-								className={
-									w.id === currentWsId
-										? "workspace-link active"
-										: "workspace-link"
-								}
-								onClick={() => setOpen(false)}
-							>
-								{w.name || "Untitled"}
-							</Link>
-						))}
-					</div>
-					<div className="mobile-workspace-create">
-						<input
-							className="workspace-bar-input"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							placeholder="New workspace name"
-						/>
-						<Button
-							onClick={async () => {
-							const n = name.trim();
-							if (!n) return;
-							await createWorkspace(n);
-							setName("");
-							setOpen(false);
-						}}
-						>
-							Create
-						</Button>
-					</div>
-					<AuthPanel
-						user={user}
-						auth={auth}
-					/>
-					<label className="theme-label">Theme</label>
-					<select
-						className="theme-select"
-						value={paletteKey}
-						onChange={(e) => setPaletteKey(e.target.value)}
-					>
-						{Object.entries(PALETTES).map(([k, v]) => (
-							<option key={k} value={k}>
-								{v.name}
-							</option>
-						))}
-					</select>
-				</div>
-			</div>
-		</div>
-	);
+                                        <button
+                                                className="mobile-menu-close"
+                                                onClick={() => setOpen(false)}
+                                        >
+                                                ✕
+                                        </button>
+                                        {user && (
+                                                <>
+                                                        <span className="greeting">
+                                                                {user.displayName || user.email}
+                                                        </span>
+                                                        <Link
+                                                                to="/profile/edit"
+                                                                className="auth-link"
+                                                                onClick={() => setOpen(false)}
+                                                        >
+                                                                Profile
+                                                        </Link>
+                                                </>
+                                        )}
+                                        <span className="mobile-menu-heading">Workspaces</span>
+                                        <div className="mobile-workspaces">
+                                                {workspaces.length === 0 && (
+                                                        <span>No workspaces yet</span>
+                                                )}
+                                                {workspaces.map((w) => (
+                                                        <Link
+                                                                key={w.id}
+                                                                to={`/workspace/${w.id}`}
+                                                                className={
+                                                                        w.id === currentWsId
+                                                                                ? "workspace-link active"
+                                                                                : "workspace-link"
+                                                                }
+                                                                onClick={() => setOpen(false)}
+                                                        >
+                                                                {w.name || "Untitled"}
+                                                        </Link>
+                                                ))}
+                                        </div>
+                                        <div className="mobile-workspace-create">
+                                                <input
+                                                        className="workspace-bar-input"
+                                                        value={name}
+                                                        onChange={(e) => setName(e.target.value)}
+                                                        placeholder="New workspace name"
+                                                />
+                                                <Button
+                                                        onClick={async () => {
+                                                                const n = name.trim();
+                                                                if (!n) return;
+                                                                await createWorkspace(n);
+                                                                setName("");
+                                                                setOpen(false);
+                                                        }}
+                                                >
+                                                        Create
+                                                </Button>
+                                        </div>
+                                        <span className="mobile-menu-heading">Theme</span>
+                                        <select
+                                                className="theme-select"
+                                                value={paletteKey}
+                                                onChange={(e) => {
+                                                        setPaletteKey(e.target.value);
+                                                        setOpen(false);
+                                                }}
+                                        >
+                                                {Object.entries(PALETTES).map(([k, v]) => (
+                                                        <option key={k} value={k}>
+                                                                {v.name}
+                                                        </option>
+                                                ))}
+                                        </select>
+                                </div>
+                        </div>
+                </div>
+        );
 }


### PR DESCRIPTION
## Summary
- show signed-in user's name and profile link at top of mobile menu
- organize mobile menu with workspace and theme sections
- close drawer after selecting navigation items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/header/mobile-menu.jsx src/components/header/header.jsx` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd0a170948326841b3e280a8ed347