### PR TITLE
feat: add mobile project selector

### DIFF
--- a/src/components/projects-overview/projects-overview.css
+++ b/src/components/projects-overview/projects-overview.css
@@ -37,9 +37,10 @@
 }
 
 .project-select {
-        width: 100%;
-        margin-bottom: 12px;
-        padding: 8px;
-        border: 1px solid var(--accent);
-        border-radius: 8px;
+	width: 100%;
+	margin-bottom: 12px;
+	padding: 8px;
+	border: 1px solid var(--accent);
+	border-radius: 8px;
+	background-color: transparent;
 }

--- a/src/components/projects-overview/projects-overview.css
+++ b/src/components/projects-overview/projects-overview.css
@@ -35,3 +35,11 @@
         border-radius: 8px;
         padding: 4px 8px;
 }
+
+.project-select {
+        width: 100%;
+        margin-bottom: 12px;
+        padding: 8px;
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+}

--- a/src/components/projects-overview/projects-overview.jsx
+++ b/src/components/projects-overview/projects-overview.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, AddRow } from "../ui/ui";
 import "./projects-overview.css";
 
@@ -14,6 +14,24 @@ export default function ProjectsOverview({
         onSelectItem,
         onUpdate,
 }) {
+        const [isMobile, setIsMobile] = useState(false);
+
+        useEffect(() => {
+                const handleResize = () => setIsMobile(window.innerWidth <= 640);
+                handleResize();
+                window.addEventListener("resize", handleResize);
+                return () => window.removeEventListener("resize", handleResize);
+        }, []);
+
+        const handleSelectChange = (e) => {
+                onSelectItem && onSelectItem(e.target.value);
+        };
+
+        const handleRowClick = (id) => {
+                if (!onSelectItem) return;
+                onSelectItem(selectedId === id ? "" : id);
+        };
+
         return (
                 <Card
                         title="Projects"
@@ -21,30 +39,47 @@ export default function ProjectsOverview({
                 >
                         {!data.length && <div className="projects-empty">No projects</div>}
 
-                        {data.map((item) => (
-                                <div
-                                        key={item.id}
-                                        className={`project-row ${
-                                                selectedId === item.id ? "selected" : ""
-                                        }`}
-                                        onClick={() => onSelectItem && onSelectItem(item.id)}
-                                >
-                                        <span>{item.name}</span>
-                                        <div className="project-actions">
-                                                <div className="project-progress">
-                                                        {computeDerivedPercent(item.id).percent}%
+                        {isMobile ? (
+                                data.length > 0 && (
+                                        <select
+                                                className="project-select"
+                                                value={selectedId || ""}
+                                                onChange={handleSelectChange}
+                                        >
+                                                <option value="">Select a project</option>
+                                                {data.map((item) => (
+                                                        <option key={item.id} value={item.id}>
+                                                                {item.name}
+                                                        </option>
+                                                ))}
+                                        </select>
+                                )
+                        ) : (
+                                data.map((item) => (
+                                        <div
+                                                key={item.id}
+                                                className={`project-row ${
+                                                        selectedId === item.id ? "selected" : ""
+                                                }`}
+                                                onClick={() => handleRowClick(item.id)}
+                                        >
+                                                <span>{item.name}</span>
+                                                <div className="project-actions">
+                                                        <div className="project-progress">
+                                                                {computeDerivedPercent(item.id).percent}%
+                                                        </div>
+                                                        {!readOnly && canDelete && (
+                                                                <button
+                                                                        onClick={() => onDelete(item.id)}
+                                                                        className="delete-button"
+                                                                >
+                                                                        Delete
+                                                                </button>
+                                                        )}
                                                 </div>
-                                                {!readOnly && canDelete && (
-                                                        <button
-                                                                onClick={() => onDelete(item.id)}
-                                                                className="delete-button"
-                                                        >
-                                                                Delete
-                                                        </button>
-                                                )}
                                         </div>
-                                </div>
-                        ))}
+                                ))
+                        )}
 
                         {!readOnly && canAdd && (
                                 <AddRow

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -264,11 +264,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                         canDelete={canDeleteProject}
                                         computeDerivedPercent={computeDerivedPercent}
                                         selectedId={selectedProjectId}
-                                        onSelectItem={(id) =>
-                                                setSelectedProjectId((prev) =>
-                                                        prev === id ? "" : id,
-                                                )
-                                        }
+                                        onSelectItem={(id) => setSelectedProjectId(id)}
                                 />
 
                                 {selectedProjectId ? (


### PR DESCRIPTION
## Summary
- add responsive logic to ProjectsOverview
- support selecting projects from a dropdown on small screens
- update workspace page to handle new selection API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "./firebase-config")*

------
https://chatgpt.com/codex/tasks/task_e_68acd2b103a483269b3bbe341754a559