### PR TITLE
Add goal assignee support

### DIFF
--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -49,6 +49,17 @@
         gap: 8px;
 }
 
+.goal-notes {
+        width: 100%;
+        min-height: 60px;
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 4px 6px;
+        resize: vertical;
+}
+
 .goal-toggle {
         background: transparent;
         color: var(--accent);

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -2,10 +2,8 @@
 	opacity: 0.7;
 }
 
+/* Base row styling */
 .list-row {
-        display: grid;
-        gap: 12px;
-        align-items: center;
         padding: 10px 0;
         border-bottom: 1px dashed var(--accent);
 }
@@ -15,16 +13,49 @@
         color: #fff;
 }
 
+/* Projects and people keep a grid layout */
+.list-row.projects,
+.list-row.people {
+        display: grid;
+        gap: 12px;
+        align-items: center;
+}
+
 .list-row.projects {
         grid-template-columns: 1fr auto;
 }
 
-.list-row.goals {
-        grid-template-columns: 1fr minmax(120px, 160px) minmax(120px, 160px) auto;
-}
-
 .list-row.people {
         grid-template-columns: 1fr minmax(120px, 160px) auto;
+}
+
+/* Goals stack vertically to avoid cramped layout */
+.list-row.goals {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+}
+
+.goal-main {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+}
+
+.goal-details {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+}
+
+.goal-toggle {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 4px 8px;
+        cursor: pointer;
 }
 
 .list-value {

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -19,7 +19,10 @@
         grid-template-columns: 1fr auto;
 }
 
-.list-row.goals,
+.list-row.goals {
+        grid-template-columns: 1fr minmax(120px, 160px) minmax(120px, 160px) auto;
+}
+
 .list-row.people {
         grid-template-columns: 1fr minmax(120px, 160px) auto;
 }
@@ -54,6 +57,12 @@
         border: 1px solid #ff4d4f;
         border-radius: 8px;
         padding: 4px 8px;
+}
+
+.goal-assignee {
+        margin-left: 8px;
+        font-size: 0.85em;
+        opacity: 0.8;
 }
 
 .list-row.goal-done span {

--- a/src/components/list/list.css
+++ b/src/components/list/list.css
@@ -49,6 +49,12 @@
         gap: 8px;
 }
 
+.goal-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+}
+
 .goal-notes {
         width: 100%;
         min-height: 60px;
@@ -67,6 +73,24 @@
         border-radius: 8px;
         padding: 4px 8px;
         cursor: pointer;
+}
+
+.note-toggle {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 4px 8px;
+        cursor: pointer;
+}
+
+.goal-note-text {
+        width: 100%;
+        background: var(--accent-subtle);
+        color: var(--accent);
+        border-radius: 8px;
+        padding: 4px 6px;
+        word-wrap: break-word;
 }
 
 .list-value {

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -21,6 +21,14 @@ export default function List({
 }) {
         const [editingId, setEditingId] = useState(null);
         const [notesDraft, setNotesDraft] = useState({});
+        const [openNotes, setOpenNotes] = useState({});
+
+        const saveNotes = (id, item) => {
+                const draft = notesDraft[id];
+                if (draft !== undefined && draft !== item.notes) {
+                        onUpdate(id, { notes: draft });
+                }
+        };
 
         return (
                 <Card
@@ -90,22 +98,42 @@ export default function List({
                                                                                         );
                                                                                 })()}
                                                                         </span>
-                                                                        <button
-                                                                                className="goal-toggle"
-                                                                                onClick={(e) => {
-                                                                                        e.stopPropagation();
-                                                                                        setEditingId(
-                                                                                                editingId === item.id
-                                                                                                        ? null
-                                                                                                        : item.id,
-                                                                                        );
-                                                                                }}
-                                                                        >
-                                                                                {editingId === item.id ? "Close" : "Edit"}
-                                                                        </button>
+                                                                        <div className="goal-actions">
+                                                                                {item.notes && (
+                                                                                        <button
+                                                                                                className="note-toggle"
+                                                                                                onClick={(e) => {
+                                                                                                        e.stopPropagation();
+                                                                                                        setOpenNotes((prev) => ({
+                                                                                                                ...prev,
+                                                                                                                [item.id]: !prev[item.id],
+                                                                                                        }));
+                                                                                                }}
+                                                                                        >
+                                                                                                {openNotes[item.id] ? "Hide note" : "Note"}
+                                                                                        </button>
+                                                                                )}
+                                                                                <button
+                                                                                        className="goal-toggle"
+                                                                                        onClick={(e) => {
+                                                                                                e.stopPropagation();
+                                                                                                if (editingId === item.id) {
+                                                                                                        saveNotes(item.id, item);
+                                                                                                        setEditingId(null);
+                                                                                                } else {
+                                                                                                        setEditingId(item.id);
+                                                                                                }
+                                                                                        }}
+                                                                                >
+                                                                                        {editingId === item.id ? "Close" : "Edit"}
+                                                                                </button>
+                                                                        </div>
                                                                 </div>
+                                                                {openNotes[item.id] && item.notes && editingId !== item.id && (
+                                                                        <div className="goal-note-text">{item.notes}</div>
+                                                                )}
                                                                 {editingId === item.id && (
-                                                                <div className="goal-details">
+                                                                        <div className="goal-details">
                                                                                 <select
                                                                                         className="status-select"
                                                                                         value={item.assigneeUid || ""}
@@ -135,20 +163,22 @@ export default function List({
                                                                                 >
                                                                                         <option value="todo">To do</option>
                                                                                         <option value="doing">Doing</option>
-                                                                                <option value="done">Done</option>
+                                                                                        <option value="done">Done</option>
                                                                                 </select>
                                                                                 <textarea
                                                                                         className="goal-notes"
-                                                                                        value={notesDraft[item.id] !== undefined ? notesDraft[item.id] : item.notes || ""}
-                                                                                        onChange={(e) =>
-                                                                                                setNotesDraft({ ...notesDraft, [item.id]: e.target.value })
+                                                                                        value={
+                                                                                                notesDraft[item.id] !== undefined
+                                                                                                        ? notesDraft[item.id]
+                                                                                                        : item.notes || ""
                                                                                         }
-                                                                                        onBlur={() => {
-                                                                                                const val = notesDraft[item.id];
-                                                                                                if (val !== undefined && val !== item.notes) {
-                                                                                                        onUpdate(item.id, { notes: val });
-                                                                                                }
-                                                                                        }}
+                                                                                        onChange={(e) =>
+                                                                                                setNotesDraft({
+                                                                                                        ...notesDraft,
+                                                                                                        [item.id]: e.target.value,
+                                                                                                })
+                                                                                        }
+                                                                                        onBlur={() => saveNotes(item.id, item)}
                                                                                         placeholder="Add notes"
                                                                                         disabled={readOnly}
                                                                                 />
@@ -162,8 +192,8 @@ export default function List({
                                                                                 )}
                                                                         </div>
                                                                 )}
-                                                        </>
-                                                )}
+                                                         </>
+                                                 )}
 
                                                 {isPeople && (
                                                         <>

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -20,6 +20,7 @@ export default function List({
         children,
 }) {
         const [editingId, setEditingId] = useState(null);
+        const [notesDraft, setNotesDraft] = useState({});
 
         return (
                 <Card
@@ -104,7 +105,7 @@ export default function List({
                                                                         </button>
                                                                 </div>
                                                                 {editingId === item.id && (
-                                                                        <div className="goal-details">
+                                                                <div className="goal-details">
                                                                                 <select
                                                                                         className="status-select"
                                                                                         value={item.assigneeUid || ""}
@@ -134,8 +135,23 @@ export default function List({
                                                                                 >
                                                                                         <option value="todo">To do</option>
                                                                                         <option value="doing">Doing</option>
-                                                                                        <option value="done">Done</option>
+                                                                                <option value="done">Done</option>
                                                                                 </select>
+                                                                                <textarea
+                                                                                        className="goal-notes"
+                                                                                        value={notesDraft[item.id] !== undefined ? notesDraft[item.id] : item.notes || ""}
+                                                                                        onChange={(e) =>
+                                                                                                setNotesDraft({ ...notesDraft, [item.id]: e.target.value })
+                                                                                        }
+                                                                                        onBlur={() => {
+                                                                                                const val = notesDraft[item.id];
+                                                                                                if (val !== undefined && val !== item.notes) {
+                                                                                                        onUpdate(item.id, { notes: val });
+                                                                                                }
+                                                                                        }}
+                                                                                        placeholder="Add notes"
+                                                                                        disabled={readOnly}
+                                                                                />
                                                                                 {!readOnly && canDelete && (
                                                                                         <button
                                                                                                 onClick={() => onDelete(item.id)}

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -16,6 +16,7 @@ export default function List({
         computeDerivedPercent = () => ({ percent: 0, count: 0 }),
         onSelectItem,
         selectedId,
+        people = [],
         children,
 }) {
         return (
@@ -61,7 +62,52 @@ export default function List({
 
                                                 {isGoals && (
                                                         <>
-                                                                <span>{item.title}</span>
+                                                                <span>
+                                                                        {item.title}
+                                                                        {(() => {
+                                                                                const assignee = people.find(
+                                                                                        (p) =>
+                                                                                                p.uid ===
+                                                                                                item.assigneeUid,
+                                                                                );
+                                                                                if (!assignee) return null;
+                                                                                const label =
+                                                                                        assignee.name ||
+                                                                                        (assignee.email || "")
+                                                                                                .split("@")[0]
+                                                                                                .split(" ")
+                                                                                                .map((s) => s[0])
+                                                                                                .join("")
+                                                                                                .toUpperCase();
+                                                                                return (
+                                                                                        <span className="goal-assignee">
+                                                                                                {label}
+                                                                                        </span>
+                                                                                );
+                                                                        })()}
+                                                                </span>
+                                                                <select
+                                                                        className="status-select"
+                                                                        value={item.assigneeUid || ""}
+                                                                        onChange={(e) =>
+                                                                                onUpdate(item.id, {
+                                                                                        assigneeUid:
+                                                                                                e.target
+                                                                                                        .value,
+                                                                                })
+                                                                        }
+                                                                        disabled={readOnly}
+                                                                >
+                                                                        <option value="">Unassigned</option>
+                                                                        {people.map((p) => (
+                                                                                <option
+                                                                                        key={p.uid}
+                                                                                        value={p.uid}
+                                                                                >
+                                                                                        {p.name || p.email}
+                                                                                </option>
+                                                                        ))}
+                                                                </select>
                                                                 <select
                                                                         className="status-select"
                                                                         value={item.status || "todo"}
@@ -130,6 +176,7 @@ export default function List({
                                         }
                                         disabled={readOnly}
                                         onAdd={onAdd}
+                                        people={people}
                                 />
                         )}
 

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Card, AddRow } from "../ui/ui";
 import "./list.css";
 
@@ -19,6 +19,8 @@ export default function List({
         people = [],
         children,
 }) {
+        const [editingId, setEditingId] = useState(null);
+
         return (
                 <Card
                         title={title}
@@ -62,73 +64,87 @@ export default function List({
 
                                                 {isGoals && (
                                                         <>
-                                                                <span>
-                                                                        {item.title}
-                                                                        {(() => {
-                                                                                const assignee = people.find(
-                                                                                        (p) =>
-                                                                                                p.uid ===
-                                                                                                item.assigneeUid,
-                                                                                );
-                                                                                if (!assignee) return null;
-                                                                                const label =
-                                                                                        assignee.name ||
-                                                                                        (assignee.email || "")
-                                                                                                .split("@")[0]
-                                                                                                .split(" ")
-                                                                                                .map((s) => s[0])
-                                                                                                .join("")
-                                                                                                .toUpperCase();
-                                                                                return (
-                                                                                        <span className="goal-assignee">
-                                                                                                {label}
-                                                                                        </span>
-                                                                                );
-                                                                        })()}
-                                                                </span>
-                                                                <select
-                                                                        className="status-select"
-                                                                        value={item.assigneeUid || ""}
-                                                                        onChange={(e) =>
-                                                                                onUpdate(item.id, {
-                                                                                        assigneeUid:
-                                                                                                e.target
-                                                                                                        .value,
-                                                                                })
-                                                                        }
-                                                                        disabled={readOnly}
-                                                                >
-                                                                        <option value="">Unassigned</option>
-                                                                        {people.map((p) => (
-                                                                                <option
-                                                                                        key={p.uid}
-                                                                                        value={p.uid}
-                                                                                >
-                                                                                        {p.name || p.email}
-                                                                                </option>
-                                                                        ))}
-                                                                </select>
-                                                                <select
-                                                                        className="status-select"
-                                                                        value={item.status || "todo"}
-                                                                        onChange={(e) =>
-                                                                                onUpdate(item.id, {
-                                                                                        status: e.target.value,
-                                                                                })
-                                                                        }
-                                                                        disabled={readOnly}
-                                                                >
-                                                                        <option value="todo">To do</option>
-                                                                        <option value="doing">Doing</option>
-                                                                        <option value="done">Done</option>
-                                                                </select>
-                                                                {!readOnly && canDelete && (
+                                                                <div className="goal-main">
+                                                                        <span>
+                                                                                {item.title}
+                                                                                {(() => {
+                                                                                        const assignee = people.find(
+                                                                                                (p) =>
+                                                                                                        p.uid ===
+                                                                                                        item.assigneeUid,
+                                                                                        );
+                                                                                        if (!assignee) return null;
+                                                                                        const label =
+                                                                                                assignee.name ||
+                                                                                                (assignee.email || "")
+                                                                                                        .split("@")[0]
+                                                                                                        .split(" ")
+                                                                                                        .map((s) => s[0])
+                                                                                                        .join("")
+                                                                                                        .toUpperCase();
+                                                                                        return (
+                                                                                                <span className="goal-assignee">
+                                                                                                        {label}
+                                                                                                </span>
+                                                                                        );
+                                                                                })()}
+                                                                        </span>
                                                                         <button
-                                                                                onClick={() => onDelete(item.id)}
-                                                                                className="delete-button"
+                                                                                className="goal-toggle"
+                                                                                onClick={(e) => {
+                                                                                        e.stopPropagation();
+                                                                                        setEditingId(
+                                                                                                editingId === item.id
+                                                                                                        ? null
+                                                                                                        : item.id,
+                                                                                        );
+                                                                                }}
                                                                         >
-                                                                                Delete
+                                                                                {editingId === item.id ? "Close" : "Edit"}
                                                                         </button>
+                                                                </div>
+                                                                {editingId === item.id && (
+                                                                        <div className="goal-details">
+                                                                                <select
+                                                                                        className="status-select"
+                                                                                        value={item.assigneeUid || ""}
+                                                                                        onChange={(e) =>
+                                                                                                onUpdate(item.id, {
+                                                                                                        assigneeUid: e.target.value,
+                                                                                                })
+                                                                                        }
+                                                                                        disabled={readOnly}
+                                                                                >
+                                                                                        <option value="">Unassigned</option>
+                                                                                        {people.map((p) => (
+                                                                                                <option key={p.uid} value={p.uid}>
+                                                                                                        {p.name || p.email}
+                                                                                                </option>
+                                                                                        ))}
+                                                                                </select>
+                                                                                <select
+                                                                                        className="status-select"
+                                                                                        value={item.status || "todo"}
+                                                                                        onChange={(e) =>
+                                                                                                onUpdate(item.id, {
+                                                                                                        status: e.target.value,
+                                                                                                })
+                                                                                        }
+                                                                                        disabled={readOnly}
+                                                                                >
+                                                                                        <option value="todo">To do</option>
+                                                                                        <option value="doing">Doing</option>
+                                                                                        <option value="done">Done</option>
+                                                                                </select>
+                                                                                {!readOnly && canDelete && (
+                                                                                        <button
+                                                                                                onClick={() => onDelete(item.id)}
+                                                                                                className="delete-button"
+                                                                                        >
+                                                                                                Delete
+                                                                                        </button>
+                                                                                )}
+                                                                        </div>
                                                                 )}
                                                         </>
                                                 )}

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -36,11 +36,16 @@
 	opacity: 0.6;
 }
 
+
 .add-row {
-	display: grid;
-	grid-template-columns: 1fr auto;
-	gap: 8px;
-	margin-top: 12px;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 8px;
+        margin-top: 12px;
+}
+
+.add-row-goal {
+        grid-template-columns: 1fr minmax(120px, 160px) auto;
 }
 
 .add-row input {
@@ -52,7 +57,19 @@
 }
 
 .add-row button {
-	border-radius: 8px;
-	border: 1px solid rgba(255, 255, 255, 0.3);
-	padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        padding: 8px 10px;
+}
+
+.add-row-goal select {
+        background: transparent;
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        padding: 4px 6px;
+}
+
+.add-row-goal select option {
+        color: #000;
 }

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -37,23 +37,21 @@
 }
 
 
+
 .add-row {
-        display: grid;
-        grid-template-columns: 1fr auto;
+        display: flex;
+        flex-wrap: wrap;
         gap: 8px;
         margin-top: 12px;
 }
 
-.add-row-goal {
-        grid-template-columns: 1fr minmax(120px, 160px) auto;
-}
-
 .add-row input {
-	background: transparent;
-	color: inherit;
-	border: 1px solid rgba(255, 255, 255, 0.2);
-	border-radius: 8px;
-	padding: 8px 10px;
+        background: transparent;
+        color: inherit;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 8px;
+        padding: 8px 10px;
+        flex: 1 1 160px;
 }
 
 .add-row button {
@@ -68,6 +66,7 @@
         border: 1px solid var(--accent);
         border-radius: 8px;
         padding: 4px 6px;
+        flex: 0 1 160px;
 }
 
 .add-row-goal select option {

--- a/src/components/ui/ui.jsx
+++ b/src/components/ui/ui.jsx
@@ -31,17 +31,20 @@ export function Button({ children, onClick, subtle, disabled }) {
 	);
 }
 
-export function AddRow({ type, onAdd, disabled, placeholder }) {
-	const [text, setText] = useState("");
-	const handleSubmit = () => {
-		const v = text.trim();
-		if (!v) return;
+export function AddRow({ type, onAdd, disabled, placeholder, people = [] }) {
+        const [text, setText] = useState("");
+        const [assigneeUid, setAssigneeUid] = useState("");
+        const handleSubmit = () => {
+                const v = text.trim();
+                if (!v) return;
                 if (type === "projects") onAdd({ name: v, percent: 0 });
-                if (type === "goals") onAdd({ title: v, status: "todo" });
-		setText("");
-	};
-	return (
-		<div className="add-row">
+                if (type === "goals")
+                        onAdd({ title: v, status: "todo", assigneeUid });
+                setText("");
+                setAssigneeUid("");
+        };
+        return (
+                <div className={`add-row ${type === "goals" ? "add-row-goal" : ""}`}>
                         <input
                                 disabled={disabled}
                                 value={text}
@@ -51,9 +54,24 @@ export function AddRow({ type, onAdd, disabled, placeholder }) {
                                 }}
                                 placeholder={placeholder}
                         />
+                        {type === "goals" && (
+                                <select
+                                        className="status-select"
+                                        value={assigneeUid}
+                                        onChange={(e) => setAssigneeUid(e.target.value)}
+                                        disabled={disabled}
+                                >
+                                        <option value="">Unassigned</option>
+                                        {people.map((p) => (
+                                                <option key={p.uid} value={p.uid}>
+                                                        {p.name || p.email}
+                                                </option>
+                                        ))}
+                                </select>
+                        )}
                         <button onClick={handleSubmit} disabled={disabled}>
                                 Add
                         </button>
                 </div>
-	);
+        );
 }

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -193,7 +193,11 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         return "";
                 }
                 try {
-                        const d = await addDoc(ref, { ...goal, createdAt: serverTimestamp() });
+                        const d = await addDoc(ref, {
+                                ...goal,
+                                assigneeUid: goal.assigneeUid || "",
+                                createdAt: serverTimestamp(),
+                        });
                         return d.id;
                 } catch (err) {
                         setBanner(`Add goal failed: ${err.message}`);
@@ -278,6 +282,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                                 readOnly={goalReadOnly}
                                                 canAdd={canAddGoal}
                                                 canDelete={canDeleteGoal}
+                                                people={people}
                                         />
                                 ) : (
                                         <Card title="Goals">

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -196,6 +196,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         const d = await addDoc(ref, {
                                 ...goal,
                                 assigneeUid: goal.assigneeUid || "",
+                                notes: goal.notes || "",
                                 createdAt: serverTimestamp(),
                         });
                         return d.id;


### PR DESCRIPTION
## Summary
- add assignee selector when managing goals and persist assigneeUid in Firestore
- allow assigning a person when creating new goals
- display assignee name or initials alongside goal titles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aeeebbbaac83269fa275170432808c