### PR TITLE
Add tabbed workspace layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,24 +21,6 @@
         color: var(--text);
 }
 
-.grid-wrap {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 24px;
-}
-
-@media (max-width: 1100px) {
-        .grid-wrap {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
-}
-
-@media (max-width: 760px) {
-        .grid-wrap {
-                grid-template-columns: 1fr;
-        }
-}
-
 .palette-info {
         opacity: 0.7;
 }

--- a/src/components/tabs/tabs.css
+++ b/src/components/tabs/tabs.css
@@ -1,0 +1,38 @@
+.tabs {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+}
+
+.tab-headers {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+}
+
+.tab-header {
+        flex: 1;
+        padding: 8px 12px;
+        background: transparent;
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        cursor: pointer;
+        color: var(--text);
+}
+
+.tab-header.active {
+        background: var(--accent);
+        color: #fff;
+}
+
+.tab-content {
+        width: 100%;
+}
+
+.tab-pane {
+        display: none;
+}
+
+.tab-pane.active {
+        display: block;
+}

--- a/src/components/tabs/tabs.jsx
+++ b/src/components/tabs/tabs.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import "./tabs.css";
+
+export default function Tabs({ tabs, activeTab, onTabChange }) {
+        return (
+                <div className="tabs">
+                        <div className="tab-headers">
+                                {tabs.map((tab) => (
+                                        <button
+                                                key={tab.id}
+                                                className={`tab-header ${
+                                                        activeTab === tab.id ? "active" : ""
+                                                }`}
+                                                onClick={() => onTabChange(tab.id)}
+                                        >
+                                                {tab.label}
+                                        </button>
+                                ))}
+                        </div>
+                        <div className="tab-content">
+                                {tabs.map((tab) => (
+                                        <div
+                                                key={tab.id}
+                                                className={`tab-pane ${
+                                                        activeTab === tab.id ? "active" : ""
+                                                }`}
+                                        >
+                                                {tab.content}
+                                        </div>
+                                ))}
+                        </div>
+                </div>
+        );
+}

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -268,41 +268,45 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                                 id: "projects",
                                                 label: "Projects",
                                                 content: (
-                                                        <ProjectsOverview
-                                                                paletteKey={paletteKey}
-                                                                data={projects}
-                                                                onAdd={(item) => addItem("projects", item)}
-                                                                onUpdate={(id, patch) => updateItem("projects", id, patch)}
-                                                                onDelete={(id) => deleteItem("projects", id)}
-                                                                readOnly={projectReadOnly}
-                                                                canAdd={canAddProject}
-                                                                canDelete={canDeleteProject}
-                                                                computeDerivedPercent={computeDerivedPercent}
-                                                                selectedId={selectedProjectId}
-                                                                onSelectItem={(id) => setSelectedProjectId(id)}
-                                                        />
-                                                ),
-                                        },
-                                        {
-                                                id: "goals",
-                                                label: "Goals",
-                                                content: selectedProjectId ? (
-                                                        <List
-                                                                title="Goals"
-                                                                type="goals"
-                                                                data={projectGoals[selectedProjectId] || []}
-                                                                onAdd={(item) => addGoalToProject(selectedProjectId, item)}
-                                                                onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
-                                                                onDelete={(id) => deleteGoal(selectedProjectId, id)}
-                                                                readOnly={goalReadOnly}
-                                                                canAdd={canAddGoal}
-                                                                canDelete={canDeleteGoal}
-                                                                people={people}
-                                                        />
-                                                ) : (
-                                                        <Card title="Goals">
-                                                                <div className="list-empty">Select a project to view goals</div>
-                                                        </Card>
+                                                        <div className="projects-view">
+                                                                <div className="projects-sidebar">
+                                                                        <ProjectsOverview
+                                                                                paletteKey={paletteKey}
+                                                                                data={projects}
+                                                                                onAdd={(item) => addItem("projects", item)}
+                                                                                onUpdate={(id, patch) => updateItem("projects", id, patch)}
+                                                                                onDelete={(id) => deleteItem("projects", id)}
+                                                                                readOnly={projectReadOnly}
+                                                                                canAdd={canAddProject}
+                                                                                canDelete={canDeleteProject}
+                                                                                computeDerivedPercent={computeDerivedPercent}
+                                                                                selectedId={selectedProjectId}
+                                                                                onSelectItem={(id) => setSelectedProjectId(id)}
+                                                                        />
+                                                                </div>
+                                                                <div className="goals-pane">
+                                                                        {selectedProjectId ? (
+                                                                                <List
+                                                                                        title="Goals"
+                                                                                        type="goals"
+                                                                                        data={projectGoals[selectedProjectId] || []}
+                                                                                        onAdd={(item) => addGoalToProject(selectedProjectId, item)}
+                                                                                        onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
+                                                                                        onDelete={(id) => deleteGoal(selectedProjectId, id)}
+                                                                                        readOnly={goalReadOnly}
+                                                                                        canAdd={canAddGoal}
+                                                                                        canDelete={canDeleteGoal}
+                                                                                        people={people}
+                                                                                />
+                                                                        ) : (
+                                                                                <Card title="Goals">
+                                                                                        <div className="list-empty">
+                                                                                                Select a project to view goals
+                                                                                        </div>
+                                                                                </Card>
+                                                                        )}
+                                                                </div>
+                                                        </div>
                                                 ),
                                         },
                                         {

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -20,6 +20,7 @@ import { db, auth } from "../../firebase";
 import ProjectsOverview from "../../components/projects-overview/projects-overview";
 import PeopleOverview from "../../components/people-overview/people-overview";
 import List from "../../components/list/list";
+import Tabs from "../../components/tabs/tabs";
 import { PALETTES, Card } from "../../components/ui/ui";
 import "./workspace.css";
 
@@ -29,6 +30,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
         const [people, setPeople] = useState([]);
         const [projectGoals, setProjectGoals] = useState({});
         const [selectedProjectId, setSelectedProjectId] = useState("");
+        const [activeTab, setActiveTab] = useState("projects");
         const [role, setRole] = useState("collaborator");
 
         useEffect(() => {
@@ -257,52 +259,71 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
 
         return (
                 <div className="workspace-page">
-                        <div className="grid-wrap">
-                                <ProjectsOverview
-                                        paletteKey={paletteKey}
-                                        data={projects}
-                                        onAdd={(item) => addItem("projects", item)}
-                                        onUpdate={(id, patch) => updateItem("projects", id, patch)}
-                                        onDelete={(id) => deleteItem("projects", id)}
-                                        readOnly={projectReadOnly}
-                                        canAdd={canAddProject}
-                                        canDelete={canDeleteProject}
-                                        computeDerivedPercent={computeDerivedPercent}
-                                        selectedId={selectedProjectId}
-                                        onSelectItem={(id) => setSelectedProjectId(id)}
-                                />
 
-                                {selectedProjectId ? (
-                                        <List
-                                                title="Goals"
-                                                type="goals"
-                                                data={projectGoals[selectedProjectId] || []}
-                                                onAdd={(item) => addGoalToProject(selectedProjectId, item)}
-                                                onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
-                                                onDelete={(id) => deleteGoal(selectedProjectId, id)}
-                                                readOnly={goalReadOnly}
-                                                canAdd={canAddGoal}
-                                                canDelete={canDeleteGoal}
-                                                people={people}
-                                        />
-                                ) : (
-                                        <Card title="Goals">
-                                                <div className="list-empty">Select a project to view goals</div>
-                                        </Card>
-                                )}
-
-                                <PeopleOverview
-                                        paletteKey={paletteKey}
-                                        data={people}
-                                        onAdd={(item) => addItem("people", item)}
-                                        onUpdate={(id, patch) => updateItem("people", id, patch)}
-                                        onDelete={(id) => deleteItem("people", id)}
-                                        readOnly={peopleReadOnly}
-                                        canAdd={canManageUsers}
-                                        canDelete={canManageUsers}
-                                />
-                        </div>
-
+                        <Tabs
+                                activeTab={activeTab}
+                                onTabChange={setActiveTab}
+                                tabs={[
+                                        {
+                                                id: "projects",
+                                                label: "Projects",
+                                                content: (
+                                                        <ProjectsOverview
+                                                                paletteKey={paletteKey}
+                                                                data={projects}
+                                                                onAdd={(item) => addItem("projects", item)}
+                                                                onUpdate={(id, patch) => updateItem("projects", id, patch)}
+                                                                onDelete={(id) => deleteItem("projects", id)}
+                                                                readOnly={projectReadOnly}
+                                                                canAdd={canAddProject}
+                                                                canDelete={canDeleteProject}
+                                                                computeDerivedPercent={computeDerivedPercent}
+                                                                selectedId={selectedProjectId}
+                                                                onSelectItem={(id) => setSelectedProjectId(id)}
+                                                        />
+                                                ),
+                                        },
+                                        {
+                                                id: "goals",
+                                                label: "Goals",
+                                                content: selectedProjectId ? (
+                                                        <List
+                                                                title="Goals"
+                                                                type="goals"
+                                                                data={projectGoals[selectedProjectId] || []}
+                                                                onAdd={(item) => addGoalToProject(selectedProjectId, item)}
+                                                                onUpdate={(id, patch) => updateGoal(selectedProjectId, id, patch)}
+                                                                onDelete={(id) => deleteGoal(selectedProjectId, id)}
+                                                                readOnly={goalReadOnly}
+                                                                canAdd={canAddGoal}
+                                                                canDelete={canDeleteGoal}
+                                                                people={people}
+                                                        />
+                                                ) : (
+                                                        <Card title="Goals">
+                                                                <div className="list-empty">Select a project to view goals</div>
+                                                        </Card>
+                                                ),
+                                        },
+                                        {
+                                                id: "people",
+                                                label: "People",
+                                                content: (
+                                                        <PeopleOverview
+                                                                paletteKey={paletteKey}
+                                                                data={people}
+                                                                onAdd={(item) => addItem("people", item)}
+                                                                onUpdate={(id, patch) => updateItem("people", id, patch)}
+                                                                onDelete={(id) => deleteItem("people", id)}
+                                                                readOnly={peopleReadOnly}
+                                                                canAdd={canManageUsers}
+                                                                canDelete={canManageUsers}
+                                                        />
+                                                ),
+                                        },
+                                ]}
+                        />
+                        
                         <div className="palette-info">
                                 <small>
                                         Palette: <span>{PALETTES[paletteKey].name}</span>

--- a/src/pages/workspace/workspace.css
+++ b/src/pages/workspace/workspace.css
@@ -3,3 +3,26 @@
         flex-direction: column;
         gap: 24px;
 }
+
+.projects-view {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+}
+
+.projects-sidebar {
+        flex: 0 0 auto;
+}
+
+.goals-pane {
+        flex: 1;
+}
+
+@media (min-width: 640px) {
+        .projects-view {
+                flex-direction: row;
+        }
+        .projects-sidebar {
+                width: 260px;
+        }
+}


### PR DESCRIPTION
## Summary
- Add reusable Tabs component with header switching
- Replace grid layout on workspace page with tabbed panes for Projects, Goals, and People
- Style tabs so only the active pane displays and remove unused grid styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "./firebase-config" from "src/firebase.js")*

------
https://chatgpt.com/codex/tasks/task_e_68af02e7b61483269a9535439f8999cc