### PR TITLE
Add owner role and refine collaborator permissions

### DIFF
--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -17,11 +17,13 @@ export default function List({
         onSelectItem,
         selectedId,
         people = [],
+        userRole = "collaborator",
         children,
 }) {
         const [editingId, setEditingId] = useState(null);
         const [notesDraft, setNotesDraft] = useState({});
         const [openNotes, setOpenNotes] = useState({});
+        const isCollaborator = userRole === "collaborator";
 
         const saveNotes = (id, item) => {
                 const draft = notesDraft[id];
@@ -142,7 +144,7 @@ export default function List({
                                                                                                         assigneeUid: e.target.value,
                                                                                                 })
                                                                                         }
-                                                                                        disabled={readOnly}
+                                                                                        disabled={readOnly || isCollaborator}
                                                                                 >
                                                                                         <option value="">Unassigned</option>
                                                                                         {people.map((p) => (
@@ -180,7 +182,7 @@ export default function List({
                                                                                         }
                                                                                         onBlur={() => saveNotes(item.id, item)}
                                                                                         placeholder="Add notes"
-                                                                                        disabled={readOnly}
+                                                                                        disabled={readOnly || isCollaborator}
                                                                                 />
                                                                                 {!readOnly && canDelete && (
                                                                                         <button
@@ -211,6 +213,7 @@ export default function List({
                                                                         }
                                                                         disabled={readOnly || item.role === "owner"}
                                                                 >
+                                                                        <option value="owner">owner</option>
                                                                         <option value="admin">admin</option>
                                                                         <option value="editor">editor</option>
                                                                         <option value="collaborator">collaborator</option>

--- a/src/components/people-overview/add-person.jsx
+++ b/src/components/people-overview/add-person.jsx
@@ -41,18 +41,19 @@ export default function AddPerson({ onAdd, disabled }) {
                                 placeholder="Email"
                                 type="email"
                         />
-                        <select
+                       <select
                                 disabled={disabled}
                                 value={role}
                                 onChange={(e) => setRole(e.target.value)}
                                 onKeyDown={(e) => {
                                         if (e.key === "Enter") handleSubmit();
                                 }}
-                        >
+                       >
+                                <option value="owner">owner</option>
                                 <option value="admin">admin</option>
                                 <option value="editor">editor</option>
                                 <option value="collaborator">collaborator</option>
-                        </select>
+                       </select>
                         <button onClick={handleSubmit} disabled={disabled}>
                                 Add
                         </button>

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -297,6 +297,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                                                                                         canAdd={canAddGoal}
                                                                                         canDelete={canDeleteGoal}
                                                                                         people={people}
+                                                                                        userRole={role}
                                                                                 />
                                                                         ) : (
                                                                                 <Card title="Goals">


### PR DESCRIPTION
## Summary
- Allow inviting users with the owner role
- Restrict collaborators to status-only goal updates
- Pass user role to goal lists for permission-aware controls

## Testing
- `npm run build` *(fails: Could not resolve "./firebase-config" from "src/firebase.js")*

------
https://chatgpt.com/codex/tasks/task_e_68af130423a88326a56d9b21c95331c7