### PR TITLE
Document Firestore rules for admin and collaborator roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ fail with *Missing or insufficient permissions*:
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function role(wsId) {
+      return get(/databases/$(database)/documents/workspaces/$(wsId))
+             .data.members[request.auth.uid];
+    }
 
     match /profiles/{uid} {
       allow read:  if request.auth != null;
       allow write: if request.auth != null && request.auth.uid == uid;
     }
 
-    // --- Workspaces (top-level) ---
     match /workspaces/{wsId} {
       // Create: requester sets themselves as owner and sole member initially
       allow create: if request.auth != null
@@ -35,24 +38,31 @@ service cloud.firestore {
       allow read: if request.auth != null
         && request.auth.uid in resource.data.memberIds;
 
-      // UPDATE/DELETE can still use the members map
+      // Owners and admins can update workspace metadata
       allow update: if request.auth != null
-        && (resource.data.members[request.auth.uid] == "owner"
-            || resource.data.members[request.auth.uid] == "editor");
+        && role(wsId) in ["owner", "admin"];
 
+      // Only owners can delete the workspace
       allow delete: if request.auth != null
-        && resource.data.members[request.auth.uid] == "owner";
-    }
+        && role(wsId) == "owner";
 
-    // --- Subcollections under a workspace ---
-    match /workspaces/{wsId}/{document=**} {
-      function parentRole() {
-        return get(/databases/$(database)/documents/workspaces/$(wsId))
-               .data.members[request.auth.uid];
+      match /projects/{projectId} {
+        allow read: if request.auth != null && role(wsId) != null;
+        allow write: if request.auth != null && role(wsId) in ["owner", "admin"];
+
+        match /goals/{goalId} {
+          allow read: if request.auth != null && role(wsId) != null;
+          allow write: if request.auth != null && (
+            role(wsId) in ["owner", "admin", "editor"] ||
+            (role(wsId) == "collaborator" && request.resource.data.keys().hasOnly(["status"]))
+          );
+        }
       }
-      allow read:  if request.auth != null && parentRole() != null;
-      allow write: if request.auth != null
-                    && (parentRole() == "owner" || parentRole() == "editor");
+
+      match /people/{personId} {
+        allow read: if request.auth != null && role(wsId) != null;
+        allow write: if request.auth != null && role(wsId) in ["owner", "admin"];
+      }
     }
 
     match /{document=**} {

--- a/firebase.json
+++ b/firebase.json
@@ -9,5 +9,8 @@
     "rewrites": [
       { "source": "**", "destination": "/index.html" }
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,52 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function role(wsId) {
+      return get(/databases/$(database)/documents/workspaces/$(wsId)).data.members[request.auth.uid];
+    }
+
+    match /profiles/{uid} {
+      allow read:  if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == uid;
+    }
+
+    match /workspaces/{wsId} {
+      allow create: if request.auth != null
+        && request.resource.data.members[request.auth.uid] == "owner"
+        && request.resource.data.memberIds == [request.auth.uid];
+
+      allow read: if request.auth != null
+        && request.auth.uid in resource.data.memberIds;
+
+      allow update: if request.auth != null
+        && role(wsId) in ["owner", "admin"];
+
+      allow delete: if request.auth != null
+        && role(wsId) == "owner";
+
+      match /projects/{projectId} {
+        allow read: if request.auth != null && role(wsId) != null;
+        allow write: if request.auth != null
+          && role(wsId) in ["owner", "admin"];
+
+        match /goals/{goalId} {
+          allow read: if request.auth != null && role(wsId) != null;
+          allow write: if request.auth != null && (
+            role(wsId) in ["owner", "admin", "editor"] ||
+            (role(wsId) == "collaborator" && request.resource.data.keys().hasOnly(["status"]))
+          );
+        }
+      }
+
+      match /people/{personId} {
+        allow read: if request.auth != null && role(wsId) != null;
+        allow write: if request.auth != null
+          && role(wsId) in ["owner", "admin"];
+      }
+    }
+
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `firestore.rules` with owner, admin, editor and collaborator permissions
- configure `firebase.json` to deploy the rules file
- update README's Firestore rules snippet to match new roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: no-unused-vars and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68af130423a88326a56d9b21c95331c7