### PR TITLE
Add realtime workspace presence indicators

### DIFF
--- a/src/components/presence-list/presence-list.css
+++ b/src/components/presence-list/presence-list.css
@@ -1,32 +1,26 @@
 .presence-list {
         display: flex;
+        align-items: center;
         gap: 4px;
+        color: #fff;
 }
 
-.presence-item {
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        background: rgba(255, 255, 255, 0.2);
-        color: #fff;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+.presence-icon {
+        width: 24px;
+        height: 24px;
+}
+
+.presence-count {
         font-size: 14px;
         font-weight: bold;
-        overflow: hidden;
-}
-
-.presence-item img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
 }
 
 @media screen and (max-width: 768px) {
-        .presence-item {
-                width: 24px;
-                height: 24px;
+        .presence-icon {
+                width: 20px;
+                height: 20px;
+        }
+        .presence-count {
                 font-size: 12px;
         }
 }

--- a/src/components/presence-list/presence-list.css
+++ b/src/components/presence-list/presence-list.css
@@ -1,0 +1,32 @@
+.presence-list {
+        display: flex;
+        gap: 4px;
+}
+
+.presence-item {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.2);
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        font-weight: bold;
+        overflow: hidden;
+}
+
+.presence-item img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+}
+
+@media screen and (max-width: 768px) {
+        .presence-item {
+                width: 24px;
+                height: 24px;
+                font-size: 12px;
+        }
+}

--- a/src/components/presence-list/presence-list.jsx
+++ b/src/components/presence-list/presence-list.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import "./presence-list.css";
+
+export default function PresenceList({ users = [] }) {
+        if (!users.length) return null;
+        return (
+                <div className="presence-list">
+                        {users.map((u) => (
+                                <div
+                                        key={u.uid || u.id}
+                                        className="presence-item"
+                                        title={u.name || u.email || ""}
+                                >
+                                        {u.photoURL ? (
+                                                <img src={u.photoURL} alt={u.name || u.email || "user"} />
+                                        ) : (
+                                                <span>
+                                                        {(u.name || u.email || "?")
+                                                                .slice(0, 1)
+                                                                .toUpperCase()}
+                                                </span>
+                                        )}
+                                </div>
+                        ))}
+                </div>
+        );
+}

--- a/src/components/presence-list/presence-list.jsx
+++ b/src/components/presence-list/presence-list.jsx
@@ -2,26 +2,17 @@ import React from "react";
 import "./presence-list.css";
 
 export default function PresenceList({ users = [] }) {
-        if (!users.length) return null;
         return (
-                <div className="presence-list">
-                        {users.map((u) => (
-                                <div
-                                        key={u.uid || u.id}
-                                        className="presence-item"
-                                        title={u.name || u.email || ""}
-                                >
-                                        {u.photoURL ? (
-                                                <img src={u.photoURL} alt={u.name || u.email || "user"} />
-                                        ) : (
-                                                <span>
-                                                        {(u.name || u.email || "?")
-                                                                .slice(0, 1)
-                                                                .toUpperCase()}
-                                                </span>
-                                        )}
-                                </div>
-                        ))}
+                <div className="presence-list" aria-label="Active users">
+                        <svg
+                                className="presence-icon"
+                                viewBox="0 0 24 24"
+                                fill="currentColor"
+                                aria-hidden="true"
+                        >
+                                <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+                        </svg>
+                        <span className="presence-count">{users.length}</span>
                 </div>
         );
 }

--- a/src/pages/workspace/index.jsx
+++ b/src/pages/workspace/index.jsx
@@ -5,6 +5,7 @@ import {
         addDoc,
         updateDoc,
         deleteDoc,
+        setDoc,
         doc,
         onSnapshot,
         serverTimestamp,
@@ -22,6 +23,7 @@ import PeopleOverview from "../../components/people-overview/people-overview";
 import List from "../../components/list/list";
 import Tabs from "../../components/tabs/tabs";
 import { PALETTES, Card } from "../../components/ui/ui";
+import PresenceList from "../../components/presence-list/presence-list";
 import "./workspace.css";
 
 export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) {
@@ -32,6 +34,7 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
         const [selectedProjectId, setSelectedProjectId] = useState("");
         const [activeTab, setActiveTab] = useState("projects");
         const [role, setRole] = useState("collaborator");
+        const [activeUsers, setActiveUsers] = useState([]);
 
         useEffect(() => {
                 if (!wsId) {
@@ -60,6 +63,32 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
                         unsubPeople();
                 };
         }, [wsId, setPaletteKey]);
+
+        useEffect(() => {
+                if (!wsId) return;
+                const base = doc(db, "workspaces", wsId);
+                const unsub = onSnapshot(collection(base, "presence"), (snap) => {
+                        setActiveUsers(
+                                snap.docs.map((d) => ({ id: d.id, ...d.data() }))
+                        );
+                });
+                return () => unsub();
+        }, [wsId, auth.currentUser?.uid]);
+
+        useEffect(() => {
+                if (!wsId || !auth.currentUser) return;
+                const uid = auth.currentUser.uid;
+                const presenceRef = doc(db, "workspaces", wsId, "presence", uid);
+                setDoc(presenceRef, {
+                        uid,
+                        name: auth.currentUser.displayName || auth.currentUser.email || "",
+                        photoURL: auth.currentUser.photoURL || "",
+                        lastActive: serverTimestamp(),
+                });
+                return () => {
+                        deleteDoc(presenceRef).catch(() => {});
+                };
+        }, [wsId]);
 
         useEffect(() => {
                 if (!wsId) return;
@@ -259,6 +288,9 @@ export default function WorkspacePage({ paletteKey, setPaletteKey, setBanner }) 
 
         return (
                 <div className="workspace-page">
+                        <div className="workspace-presence">
+                                <PresenceList users={activeUsers} />
+                        </div>
 
                         <Tabs
                                 activeTab={activeTab}

--- a/src/pages/workspace/workspace.css
+++ b/src/pages/workspace/workspace.css
@@ -4,6 +4,11 @@
         gap: 24px;
 }
 
+.workspace-presence {
+        display: flex;
+        justify-content: flex-end;
+}
+
 .projects-view {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## Summary
- track active users in `workspaces/{wsId}/presence/{uid}`
- subscribe to presence updates in Workspace page
- render active collaborators with new `PresenceList` component and styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "./firebase-config" from "src/firebase.js")*

------
https://chatgpt.com/codex/tasks/task_e_68af22e3eba08326946f2103a897336d